### PR TITLE
chore: create PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,54 @@
-Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):
+## Summary of changes
+<!-- Add description of work done here -->
+- Add ???
+- Fix ???
 
-Fix #<gh-issue-id>
+## Relevant Links
+- Designs: [Figma](FIGMA_URL)
+- Story: [ADB-XX](https://sparkbox.atlassian.net/browse/ADB-XX)
 
-Test URLs:
+## Test URLs:
 - Before: https://main--aem-block-collection--adobe.hlx.page
 - After: https://<branch>--aem-block-collection--adobe.hlx.page
+
+## Checklist
+<!-- Delete anything irrelevant to this PR -->
+* [ ] This PR has visual changes, and has been reviewed by a designer.
+* [ ] This PR has code changes, and our linters still pass.
+* [ ] This PR has new code, so new tests were added or updated, and they pass.
+* [ ] This PR affects production code, so it was browser tested (see below).
+* [ ] This PR has copy changes, so copy was proofread and approved.
+* [ ] The content of this PR requires documentation, so we added a detailed description of the component's purpose, requirements, quirks, and instructions for use by designers and developers. This includes accessibility information if pertinent.
+
+## Validation
+1. Make sure all PR checks have passed.
+2. Pull down all related branches.
+<!-- Add additional validation steps here -->
+
+---
+
+## Browser Testing
+We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.
+
+Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.
+
+**Windows**
+* [ ] Firefox
+* [ ] Chrome
+* [ ] Edge
+
+**MacOS**
+* [ ] Firefox
+* [ ] Chrome
+* [ ] Safari
+* [ ] Edge
+
+**Android**
+* [ ] Firefox
+* [ ] Chrome
+* [ ] Edge
+
+**iOS**
+* [ ] Safari
+
+---

--- a/.github/public_PULL_REQUEST_TEMPLATE.md
+++ b/.github/public_PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):
+
+Fix #<gh-issue-id>
+
+Test URLs:
+- Before: https://main--aem-block-collection--adobe.hlx.page
+- After: https://<branch>--aem-block-collection--adobe.hlx.page


### PR DESCRIPTION
## Summary of changes
- Create PR template
- Rename previous iteration of PR template to allow reversion later

## Relevant Links
- Story: [ADB-73](https://sparkbox.atlassian.net/browse/ADB-73)

## Test URLs:
- Before: https://main--aem-block-collection--adobe.hlx.page
- After: https://ADB-73--aem-block-collection--adobe.hlx.page

## Validation
1. Review `.github/PULL_REQUEST_TEMPLATE.md`
2. That's it, really. I'm open to thoughts/feedback/suggestions.