### PR TITLE
chore: Adds Pattern Library page and puppeteer test

### DIFF
--- a/tests/pattern-library.test.js
+++ b/tests/pattern-library.test.js
@@ -1,0 +1,21 @@
+const puppeteer = require('puppeteer');
+
+describe('Pattern Library Page', () => {
+    let browser;
+    let page;
+
+    beforeAll(async () => {
+        browser = await puppeteer.launch();
+        page = await browser.newPage();
+        await page.goto('https://main--adobe-design-website--adobe.aem.live/pattern-library/');
+    });
+
+    afterAll(async () => {
+        await browser.close();
+    });
+
+    test('should have a title', async () => {
+        const h1 = await page.$('h1');
+        expect(h1).not.toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary of changes
<!-- Add description of work done here -->
- Adds Pattern Library Page: https://main--adobe-design-website--adobe.aem.live/pattern-library/
- Adds initial pattern library puppeteer test

## Relevant Links
- Designs: [Figma](FIGMA_URL)
- Story: [ADB-104](https://sparkbox.atlassian.net/browse/ADB-104)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page
- After: https://ADB-104-pattern-library--adobe-design-website--adobe.aem.page/pattern-library/

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. Verify puppeteer test created for pattern library page
4. Verify tests pass for pattern library test
