### PR TITLE
feat: add husky for linting/tests on git push

### DIFF
--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+npm run lint && npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "eslint": "^9.22.0",
         "eslint-plugin-import": "^2.31.0",
         "globals": "^16.0.0",
+        "husky": "^9.1.7",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "puppeteer": "^24.4.0",
@@ -4359,6 +4360,21 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint": "^9.22.0",
     "eslint-plugin-import": "^2.31.0",
     "globals": "^16.0.0",
+    "husky": "^9.1.7",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "puppeteer": "^24.4.0",


### PR DESCRIPTION
## Summary of changes
<!-- Add description of work done here -->
- adds husky
- adds pre-push hook to run` npm run lint` and `npm run test` on `git push`

## Relevant Links
- Designs: [Figma](FIGMA_URL)
- Story: [ADB-212](https://sparkbox.atlassian.net/browse/ADB-212)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://ADB-212-git-push-linting-tests--adobe-design-website--adobe.aem.page/

## Checklist
<!-- Delete anything irrelevant to this PR -->

* [ ] This PR has code changes, and our linters still pass.

## Validation
1. Make sure all PR checks have passed.
2. Pull down this branch
3. Create a linting error and failing test locally
4. Create a temporary commit and attempt to push to this branch
5. Verify you are not able to push to this branch until linting and tests are passed

