### PR TITLE
feat: Blockquote

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "custom-property-empty-line-before": null
+  }
+} 

--- a/blocks/quote/quote.css
+++ b/blocks/quote/quote.css
@@ -8,24 +8,8 @@
   line-height: 1.4;
   letter-spacing: 0;
   color: var(--color-text);
-}
-
-.quote blockquote::before,
-.quote blockquote::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background-color: var(--color-border);
-}
-
-.quote blockquote::before {
-  top: 0;
-}
-
-.quote blockquote::after {
-  bottom: 0;
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .quote blockquote p {
@@ -40,12 +24,15 @@
 }
 
 .quote blockquote .quote-attribution {
-  margin-block-start: 2rem;
+  margin-block-start: 0.5rem;
 
   & p {
     color: var(--color-text);
-    font-size: 1.5rem;
+    font-size: 0.875rem;
+    font-family: var(--spectrum-font-family);
     font-style: normal;
+    font-weight: var(--spectrum-medium-font-weight);
+    line-height: 1.25;
   }
 
   & a:hover {
@@ -57,9 +44,4 @@
   & cite {
     display: flex;
   }
-}
-
-.quote blockquote .quote-attribution > :first-child::before {
-  content: "—";
-  padding-right: 0.5ch;
 }

--- a/blocks/quote/quote.css
+++ b/blocks/quote/quote.css
@@ -12,12 +12,18 @@
 }
 
 .quote__quotation {
-  font-size: 1.75rem;
+  font-size: 1.25rem;
   margin: 0;
-}
 
-@media (min-width: 48rem) {
-  .quote__quotation {
+  @media (min-width: 48rem) {
+    font-size: 1.75rem;
+  }
+
+  @media (min-width: 80rem) {
+    font-size: 2rem;
+  }
+
+  @media (min-width: 105rem) {
     font-size: 2.25rem;
   }
 }

--- a/blocks/quote/quote.css
+++ b/blocks/quote/quote.css
@@ -8,8 +8,7 @@
   line-height: 1.4;
   letter-spacing: 0;
   color: var(--color-text);
-  border-top: 1px solid var(--color-border);
-  border-bottom: 1px solid var(--color-border);
+  border-block: 1px solid var(--color-border);
 }
 
 .quote blockquote p {

--- a/blocks/quote/quote.css
+++ b/blocks/quote/quote.css
@@ -1,39 +1,65 @@
 .quote blockquote {
-  margin: 0 auto;
-  padding: 0 1.5rem;
-  max-width: 48rem;
+  --color-text: light-dark(var(--spectrum-gray-700), var(--spectrum-gray-900));
+  --color-border: light-dark(
+    var(--spectrum-gray-400),
+    var(--spectrum-gray-700)
+  );
+  position: relative;
+  margin: var(--spectrum-spacing-800) auto;
+  padding-block: 4.5rem;
+  font-family: var(--spectrum-serif-font-family);
+  line-height: 1.4;
+  letter-spacing: 0;
+  color: var(--color-text);
+}
+
+.quote blockquote::before,
+.quote blockquote::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background-color: var(--color-border);
+}
+
+.quote blockquote::before {
+  top: 0;
+}
+
+.quote blockquote::after {
+  bottom: 0;
+}
+
+.quote blockquote p {
+  font-size: 1.75rem;
+  margin: 0;
 }
 
 @media (min-width: 48rem) {
-  /* !! min-width MQ needs refactor */
-  .quote blockquote {
-    padding: 0 2rem;
+  .quote blockquote p {
+    font-size: 2.25rem;
   }
 }
 
-.quote blockquote .quote-quotation {
-  font-size: 120%;
-}
-
-.quote blockquote .quote-quotation > :first-child {
-  text-indent: -0.5ch;
-}
-
-.quote blockquote .quote-quotation > :first-child::before,
-.quote blockquote .quote-quotation > :last-child::after {
-  line-height: 0;
-}
-
-.quote blockquote .quote-quotation > :first-child::before {
-  content: "“";
-}
-
-.quote blockquote .quote-quotation > :last-child::after {
-  content: "”";
-}
-
 .quote blockquote .quote-attribution {
-  text-align: right;
+  margin-block-start: 2rem;
+
+  & p {
+    color: var(--color-text);
+    font-size: 1.5rem;
+    font-style: normal;
+  }
+
+  & a:hover {
+    & p {
+      color: var(--color-text-link-hover);
+    }
+  }
+
+  & cite {
+    display: flex;
+  }
 }
 
 .quote blockquote .quote-attribution > :first-child::before {

--- a/blocks/quote/quote.css
+++ b/blocks/quote/quote.css
@@ -11,36 +11,21 @@
   border-block: 1px solid var(--color-border);
 }
 
-.quote blockquote p {
+.quote__quotation {
   font-size: 1.75rem;
   margin: 0;
 }
 
 @media (min-width: 48rem) {
-  .quote blockquote p {
+  .quote__quotation {
     font-size: 2.25rem;
   }
 }
 
-.quote blockquote .quote-attribution {
+.quote__attribution {
   margin-block-start: 0.5rem;
 
-  & p {
-    color: var(--color-text);
-    font-size: 0.875rem;
-    font-family: var(--spectrum-font-family);
+  & a {
     font-style: normal;
-    font-weight: var(--spectrum-medium-font-weight);
-    line-height: 1.25;
-  }
-
-  & a:hover {
-    & p {
-      color: var(--color-text-link-hover);
-    }
-  }
-
-  & cite {
-    display: flex;
   }
 }

--- a/blocks/quote/quote.css
+++ b/blocks/quote/quote.css
@@ -1,9 +1,6 @@
 .quote blockquote {
-  --color-text: light-dark(var(--spectrum-gray-700), var(--spectrum-gray-900));
-  --color-border: light-dark(
-    var(--spectrum-gray-400),
-    var(--spectrum-gray-700)
-  );
+  --color-text: var(--spectrum-gray-700);
+  --color-border: var(--spectrum-gray-400);
   position: relative;
   margin: var(--spectrum-spacing-800) auto;
   padding-block: 4.5rem;

--- a/blocks/quote/quote.js
+++ b/blocks/quote/quote.js
@@ -1,20 +1,30 @@
 export default async function decorate(block) {
-  const [quotation, attribution] = [...block.children].map((c) => c.firstElementChild);
+  const [quotation, attribution, attributionUrl] = [...block.children].map((child) => child.firstElementChild);
   const blockquote = document.createElement('blockquote');
-  // decorate quotation
+
   quotation.className = 'quote-quotation';
   blockquote.append(quotation);
-  // decoration attribution
+
   if (attribution) {
     attribution.className = 'quote-attribution';
+    const cite = document.createElement('cite');
+    const attributionText = document.createElement('p');
+    
+    if (attributionUrl) {
+      const link = document.createElement('a');
+      link.href = attributionUrl.textContent;
+      link.innerHTML = attribution.innerHTML;
+      attributionText.append(link);
+    } else {
+      attributionText.innerHTML = attribution.innerHTML;
+    }
+    
+    cite.append(attributionText);
+    attribution.innerHTML = '';
+    attribution.append(cite);
     blockquote.append(attribution);
-    const ems = attribution.querySelectorAll('em');
-    ems.forEach((em) => {
-      const cite = document.createElement('cite');
-      cite.innerHTML = em.innerHTML;
-      em.replaceWith(cite);
-    });
   }
+
   block.innerHTML = '';
   block.append(blockquote);
 }

--- a/blocks/quote/quote.js
+++ b/blocks/quote/quote.js
@@ -4,7 +4,7 @@ export default async function decorate(block) {
 
   const quoteText = document.createElement('p');
   quoteText.className = 'quote__quotation';
-  quoteText.innerHTML = quotation.innerHTML;
+  quoteText.innerHTML = quotation.innerText;
   blockquote.append(quoteText);
 
   if (attribution) {

--- a/blocks/quote/quote.js
+++ b/blocks/quote/quote.js
@@ -1,28 +1,28 @@
 export default async function decorate(block) {
-  const [quotation, attribution, attributionUrl] = [...block.children].map((child) => child.firstElementChild);
+  const [quotation, attribution, attributionUrl] = [...block.children].map((c) => c.firstElementChild);
   const blockquote = document.createElement('blockquote');
 
-  quotation.className = 'quote-quotation';
-  blockquote.append(quotation);
+  const quoteText = document.createElement('p');
+  quoteText.className = 'quote__quotation';
+  quoteText.innerHTML = quotation.innerHTML;
+  blockquote.append(quoteText);
 
   if (attribution) {
-    attribution.className = 'quote-attribution';
-    const cite = document.createElement('cite');
     const attributionText = document.createElement('p');
+    attributionText.className = 'quote__attribution util-detail-s';
+    const cite = document.createElement('cite');
     
     if (attributionUrl) {
       const link = document.createElement('a');
       link.href = attributionUrl.textContent;
-      link.innerHTML = attribution.innerHTML;
-      attributionText.append(link);
+      link.textContent = attribution.textContent;
+      cite.append(link);
     } else {
-      attributionText.innerHTML = attribution.innerHTML;
+      cite.textContent = attribution.textContent;
     }
     
-    cite.append(attributionText);
-    attribution.innerHTML = '';
-    attribution.append(cite);
-    blockquote.append(attribution);
+    attributionText.append(cite);
+    blockquote.append(attributionText);
   }
 
   block.innerHTML = '';

--- a/blocks/quote/quote.test.js
+++ b/blocks/quote/quote.test.js
@@ -3,9 +3,41 @@ describe('Quote Block', () => {
     await page.goto(`${global.BASE_URL}pattern-library/`);
   });
 
-  it('should render the quote wrapper', async () => {
-    await page.waitForSelector('.quote-wrapper');
-    const quoteWrapper = await page.$('.quote-wrapper');
-    expect(quoteWrapper).toExist();
+  it('should render the blockquote element', async () => {
+    await page.waitForSelector('.quote blockquote');
+    const blockquote = await page.$('.quote blockquote');
+    expect(blockquote).toExist();
+  });
+
+  it('should render the quote text', async () => {
+    await page.waitForSelector('.quote-quotation');
+    const quoteText = await page.$('.quote-quotation');
+    expect(quoteText).toExist();
+  });
+
+  it('should render the attribution when present', async () => {
+    await page.waitForSelector('.quote-attribution');
+    const attribution = await page.$('.quote-attribution');
+    expect(attribution).toExist();
+  });
+
+  it('should render the attribution with cite element', async () => {
+    await page.waitForSelector('.quote-attribution cite');
+    const cite = await page.$('.quote-attribution cite');
+    expect(cite).toExist();
+  });
+
+  it('should render the attribution text in a paragraph', async () => {
+    await page.waitForSelector('.quote-attribution cite p');
+    const attributionText = await page.$('.quote-attribution cite p');
+    expect(attributionText).toExist();
+  });
+
+  it('should render attribution link when URL is provided', async () => {
+    await page.waitForSelector('.quote-attribution cite p a');
+    const attributionLink = await page.$('.quote-attribution cite p a');
+    if (attributionLink) {
+      expect(attributionLink).toExist();
+    }
   });
 });

--- a/blocks/quote/quote.test.js
+++ b/blocks/quote/quote.test.js
@@ -10,32 +10,32 @@ describe('Quote Block', () => {
   });
 
   it('should render the quote text', async () => {
-    await page.waitForSelector('.quote-quotation');
-    const quoteText = await page.$('.quote-quotation');
+    await page.waitForSelector('.quote__quotation');
+    const quoteText = await page.$('.quote__quotation');
     expect(quoteText).toExist();
   });
 
   it('should render the attribution when present', async () => {
-    await page.waitForSelector('.quote-attribution');
-    const attribution = await page.$('.quote-attribution');
+    await page.waitForSelector('.quote__attribution');
+    const attribution = await page.$('.quote__attribution');
     expect(attribution).toExist();
   });
 
   it('should render the attribution with cite element', async () => {
-    await page.waitForSelector('.quote-attribution cite');
-    const cite = await page.$('.quote-attribution cite');
+    await page.waitForSelector('.quote__attribution cite');
+    const cite = await page.$('.quote__attribution cite');
     expect(cite).toExist();
   });
 
-  it('should render the attribution text in a paragraph', async () => {
-    await page.waitForSelector('.quote-attribution cite p');
-    const attributionText = await page.$('.quote-attribution cite p');
-    expect(attributionText).toExist();
+  it('should render the attribution with utility class', async () => {
+    await page.waitForSelector('.quote__attribution.util-detail-s');
+    const attribution = await page.$('.quote__attribution.util-detail-s');
+    expect(attribution).toExist();
   });
 
   it('should render attribution link when URL is provided', async () => {
-    await page.waitForSelector('.quote-attribution cite p a');
-    const attributionLink = await page.$('.quote-attribution cite p a');
+    await page.waitForSelector('.quote__attribution cite a');
+    const attributionLink = await page.$('.quote__attribution cite a');
     if (attributionLink) {
       expect(attributionLink).toExist();
     }


### PR DESCRIPTION
## Summary of changes
<!-- Add description of work done here -->
- Refactors and restyles Blockquote component
- Adds tests
- Adds a stylelint config to remove rule causing linting errors in `base.css`

*Jelly providing additional designs for attribution

## Relevant Links
- Designs: [Figma](https://www.figma.com/design/QzvOszpLGT7fwSd6N7gaDW/Adobe-Design?node-id=718-14332&m=dev)
- Story: [ADB-173](https://sparkbox.atlassian.net/browse/ADB-173)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://ADb-173-blockquote--adobe-design-website--adobe.aem.page/

## Checklist
<!-- Delete anything irrelevant to this PR -->
* [ ] This PR has visual changes, and has been reviewed by a designer.
* [x] This PR has code changes, and our linters still pass.
* [x] This PR has new code, so new tests were added or updated, and they pass.

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. Verify Blockquote align with [mockups](https://www.figma.com/design/QzvOszpLGT7fwSd6N7gaDW/Adobe-Design?node-id=718-14332&m=dev)
4. Verify all tests are passing

