### PR TITLE
feat: containers have wrapper classes that align with BEM best practice

### DIFF
--- a/blocks/accordion/accordion.test.js
+++ b/blocks/accordion/accordion.test.js
@@ -4,8 +4,8 @@ describe('Accordion Block', () => {
   });
 
   it('should render the accordion wrapper', async () => {
-    await page.waitForSelector('.accordion-wrapper');
-    const accordionWrapper = await page.$('.accordion-wrapper');
+    await page.waitForSelector('.accordion');
+    const accordionWrapper = await page.$('.accordion');
     expect(accordionWrapper).toExist();
   });
-}); 
+});

--- a/blocks/cards/cards.test.js
+++ b/blocks/cards/cards.test.js
@@ -4,8 +4,8 @@ describe('Cards Block', () => {
   });
 
   it('should render the cards wrapper', async () => {
-    await page.waitForSelector('.cards-wrapper');
-    const cardsWrapper = await page.$('.cards-wrapper');
+    await page.waitForSelector('.cards');
+    const cardsWrapper = await page.$('.cards');
     expect(cardsWrapper).toExist();
   });
 });

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -1,33 +1,33 @@
-.columns > div > div {
+.columns > div {
   display: flex;
   flex-direction: column;
 }
 
-.columns > div img {
+.columns img {
   width: 100%;
 }
 
-.columns > div > div > div {
+.columns > div > div {
   order: 1;
 }
 
-.columns > div > div > .columns-img-col {
+.columns > div > .columns-img-col {
   order: 0;
 }
 
-.columns > div > div > .columns-img-col img {
+.columns > div > .columns-img-col img {
   display: block;
 }
 
 @media (min-width: 48rem) {
   /* !! min-width MQ needs refactor */
-  .columns > div > div {
+  .columns > div {
     align-items: center;
     flex-direction: unset;
     gap: 24px;
   }
 
-  .columns > div > div > div {
+  .columns > div > div {
     flex: 1;
     order: unset;
   }

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -1,33 +1,33 @@
-.columns > div {
+.columns > div > div {
   display: flex;
   flex-direction: column;
 }
 
-.columns img {
+.columns > div img {
   width: 100%;
 }
 
-.columns > div > div {
+.columns > div > div > div {
   order: 1;
 }
 
-.columns > div > .columns-img-col {
+.columns > div > div > .columns-img-col {
   order: 0;
 }
 
-.columns > div > .columns-img-col img {
+.columns > div > div > .columns-img-col img {
   display: block;
 }
 
 @media (min-width: 48rem) {
   /* !! min-width MQ needs refactor */
-  .columns > div {
+  .columns > div > div {
     align-items: center;
     flex-direction: unset;
     gap: 24px;
   }
 
-  .columns > div > div {
+  .columns > div > div > div {
     flex: 1;
     order: unset;
   }

--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -1,8 +1,8 @@
 export default function decorate(block) {
+  const blockWrapper = block.parentElement;
+  blockWrapper.classList.add('columns-wrapper');
+
   const cols = [...block.firstElementChild.children];
-  // removing the duplicate nested columns class
-  // this component will be updated later
-  block.classList.remove(`columns`);
   block.classList.add(`columns-${cols.length}-cols`);
 
   // setup image columns

--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -1,5 +1,8 @@
 export default function decorate(block) {
   const cols = [...block.firstElementChild.children];
+  // removing the duplicate nested columns class
+  // this component will be updated later
+  block.classList.remove(`columns`);
   block.classList.add(`columns-${cols.length}-cols`);
 
   // setup image columns

--- a/blocks/columns/columns.test.js
+++ b/blocks/columns/columns.test.js
@@ -4,9 +4,9 @@ describe('Columns Block', () => {
     await page.goto(`${global.BASE_URL}pattern-library/`);
   });
 
-  it('should render the columns wrapper', async () => {
-    await page.waitForSelector('.columns-wrapper');
-    const columnsWrapper = await page.$('.columns-wrapper');
+  it('should render the columns', async () => {
+    await page.waitForSelector('.columns');
+    const columnsWrapper = await page.$('.columns');
     expect(columnsWrapper).toExist();
   });
 
@@ -17,4 +17,4 @@ describe('Columns Block', () => {
     const divsInColumns = await page.$$('.columns > div');
     expect(divsInColumns.length).toBeGreaterThan(1);
   });
-}); 
+});

--- a/blocks/filter-group/filter-group.css
+++ b/blocks/filter-group/filter-group.css
@@ -1,6 +1,6 @@
-/* !important added to override system styles to maintain cutoff 
+/* !important added to override system styles to maintain cutoff
 effect on filter buttons to indicate horizontal scroll */
-.filter-group-wrapper {
+.filter-group {
   padding-right: 0 !important;
   margin: 1.5rem auto !important;
 

--- a/blocks/filter-group/filter-group.js
+++ b/blocks/filter-group/filter-group.js
@@ -1,5 +1,5 @@
 export default async function decorate(block) {
-    const wrapper = block.closest('.filter-group-wrapper');
+    const wrapper = block.closest('.filter-group');
 
     const label = document.createElement('div');
     label.className = 'filter-group__label util-body-s';
@@ -19,7 +19,7 @@ export default async function decorate(block) {
         button.className = 'filter-group__button util-detail-m';
         button.textContent = filter.textContent;
         button.setAttribute('type', 'button');
-        
+
         // Set initial selected state
         if (i === 0) {
             button.classList.add('filter-group__button--selected');

--- a/blocks/filter-group/filter-group.js
+++ b/blocks/filter-group/filter-group.js
@@ -1,6 +1,6 @@
 export default async function decorate(block) {
     const wrapper = block.parentElement;
-    wrapper.classList.add('.filter-group-wrapper');
+    wrapper.classList.add('filter-group-wrapper');
 
     const label = document.createElement('div');
     label.className = 'filter-group__label util-body-s';

--- a/blocks/filter-group/filter-group.js
+++ b/blocks/filter-group/filter-group.js
@@ -1,5 +1,6 @@
 export default async function decorate(block) {
-    const wrapper = block.closest('.filter-group');
+    const wrapper = block.parentElement;
+    wrapper.classList.add('.filter-group-wrapper');
 
     const label = document.createElement('div');
     label.className = 'filter-group__label util-body-s';

--- a/blocks/footer/footer.test.js
+++ b/blocks/footer/footer.test.js
@@ -4,8 +4,8 @@ describe('Footer Block', () => {
   });
 
   it('should render the footer block', async () => {
-    await page.waitForSelector('.footer-wrapper');
-    const footer = await page.$('.footer-wrapper');
+    await page.waitForSelector('.footer');
+    const footer = await page.$('.footer');
     expect(footer).toExist();
   });
-}); 
+});

--- a/blocks/form/form-fields.js
+++ b/blocks/form/form-fields.js
@@ -227,6 +227,7 @@ const FIELD_CREATOR_FUNCTIONS = {
 };
 
 export default async function createField(fd, form) {
+
   fd.Id = fd.Id || generateFieldId(fd);
   const type = fd.Type.toLowerCase();
   const createFieldFunc = FIELD_CREATOR_FUNCTIONS[type] || createInput;

--- a/blocks/form/form.test.js
+++ b/blocks/form/form.test.js
@@ -1,46 +1,46 @@
 describe('Form Block', () => {
   beforeAll(async () => {
     await page.goto(`${global.BASE_URL}pattern-library/`);
-    await page.waitForSelector('.form-wrapper', { visible: true }); 
+    await page.waitForSelector('.form', { visible: true });
   });
 
   it('should render the form wrapper', async () => {
-    const formWrapper = await page.$('.form-wrapper');
+    const formWrapper = await page.$('.form');
     expect(formWrapper).toExist();
   });
 
   it('should contain text inputs', async () => {
-    const textInputs = await page.$$('.form-wrapper input[type="text"]');
+    const textInputs = await page.$$('.form input[type="text"]');
     expect(textInputs.length).toBeGreaterThan(0);
   });
 
   it('should contain radio buttons', async () => {
-    const radioButtons = await page.$$('.form-wrapper input[type="radio"]');
+    const radioButtons = await page.$$('.form input[type="radio"]');
     expect(radioButtons.length).toBeGreaterThan(0);
   });
 
   it('should contain checkboxes', async () => {
-    const checkboxes = await page.$$('.form-wrapper input[type="checkbox"]');
+    const checkboxes = await page.$$('.form input[type="checkbox"]');
     expect(checkboxes.length).toBeGreaterThan(0);
   });
 
   it('should contain a textarea', async () => {
-    const textareas = await page.$$('.form-wrapper textarea');
+    const textareas = await page.$$('.form textarea');
     expect(textareas.length).toBeGreaterThan(0);
   });
 
   it('should contain a toggle switch', async () => {
-    const toggles = await page.$$('.form-wrapper input[type="checkbox"].toggle');
+    const toggles = await page.$$('.form input[type="checkbox"].toggle');
     expect(toggles.length).toBeGreaterThan(0);
   });
 
   it('should contain a select dropdown', async () => {
-    const selects = await page.$$('.form-wrapper select');
+    const selects = await page.$$('.form select');
     expect(selects.length).toBeGreaterThan(0);
   });
 
   it('should contain a submit button', async () => {
-    const submitButtons = await page.$$('.form-wrapper button[type="submit"]');
+    const submitButtons = await page.$$('.form button[type="submit"]');
     expect(submitButtons.length).toBeGreaterThan(0);
   });
 });

--- a/blocks/fragment/fragment.test.js
+++ b/blocks/fragment/fragment.test.js
@@ -4,8 +4,8 @@ describe('Fragment Block', () => {
   });
 
   it('should render the fragment block', async () => {
-    await page.waitForSelector('.fragment-wrapper');
-    const fragment = await page.$('.fragment-wrapper');
+    await page.waitForSelector('.fragment');
+    const fragment = await page.$('.fragment');
     expect(fragment).toExist();
   });
-}); 
+});

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -227,17 +227,17 @@ header nav .nav-sections ul > li > ul > li {
     margin: 0;
   }
 
-  header nav .nav-sections .default-content-wrapper > ul > li {
+  header nav .nav-sections > ul > li {
     flex: 0 1 auto;
     position: relative;
   }
 
-  header nav .nav-sections .default-content-wrapper > ul > li > ul {
+  header nav .nav-sections > ul > li > ul {
     display: none;
     position: relative;
   }
 
-  header nav .nav-sections .default-content-wrapper > ul > li[aria-expanded='true'] > ul {
+  header nav .nav-sections > ul > li[aria-expanded='true'] > ul {
     display: block;
     position: absolute;
     left: -24px;
@@ -249,7 +249,7 @@ header nav .nav-sections ul > li > ul > li {
     z-index: 1;
   }
 
-  header nav .nav-sections .default-content-wrapper > ul > li > ul::before {
+  header nav .nav-sections > ul > li > ul::before {
     content: '';
     position: absolute;
     top: -8px;
@@ -261,7 +261,7 @@ header nav .nav-sections ul > li > ul > li {
     border-bottom: 8px solid var(--spectrum-gray-50);
   }
 
-  header nav .nav-sections .default-content-wrapper > ul > li > ul > li {
+  header nav .nav-sections > ul > li > ul > li {
     padding: 8px 0;
   }
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -57,6 +57,7 @@ function focusNavSection() {
  * @param {Boolean} expanded Whether the element should be expanded or collapsed
  */
 function toggleAllNavSections(sections, expanded = false) {
+  // TODO: refactor in nav work
   sections.querySelectorAll('.nav-sections .default-content-wrapper > ul > li').forEach((section) => {
     section.setAttribute('aria-expanded', expanded);
   });
@@ -199,6 +200,7 @@ export default async function decorate(block) {
 
   const navSections = nav.querySelector('.nav-sections');
   if (navSections) {
+    // TODO: refactor in nav work
     navSections.querySelectorAll(':scope .default-content-wrapper > ul > li').forEach((navSection) => {
       if (navSection.querySelector('ul')) navSection.classList.add('nav-drop');
       navSection.addEventListener('click', () => {

--- a/blocks/header/header.test.js
+++ b/blocks/header/header.test.js
@@ -4,8 +4,8 @@ describe('Header Block', () => {
   });
 
   it('should render the header wrapper', async () => {
-    await page.waitForSelector('.header-wrapper');
-    const headerWrapper = await page.$('.header-wrapper');
+    await page.waitForSelector('.header');
+    const headerWrapper = await page.$('.header');
     expect(headerWrapper).toExist();
   });
-}); 
+});

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -1,10 +1,11 @@
-.hero-container .hero-wrapper {
+.hero-container {
   max-width: unset;
   padding: 0;
 }
 
 .hero {
   position: relative;
+  max-width: unset;
   padding: 2.5rem 1.5rem;
   min-height: 18.75rem;
 }

--- a/blocks/hero/hero.test.js
+++ b/blocks/hero/hero.test.js
@@ -3,28 +3,28 @@ describe('Hero Block', () => {
     await page.goto(`${global.BASE_URL}pattern-library/`);
   });
 
-  it('should render the hero wrapper', async () => {
-    await page.waitForSelector('.hero-wrapper');
-    const heroWrapper = await page.$('.hero-wrapper');
+  it('should render the hero', async () => {
+    await page.waitForSelector('.hero');
+    const heroWrapper = await page.$('.hero');
     expect(heroWrapper).toExist();
   });
 
   it('should contain an h1 heading', async () => {
-    const heading = await page.$('.hero-wrapper h1');
+    const heading = await page.$('.hero h1');
     expect(heading).toExist();
   });
 
   xit("should contain a responsive picture element", async () => {
-    await page.waitForSelector(".hero-wrapper picture");
-    const picture = await page.$(".hero-wrapper picture");
+    await page.waitForSelector(".hero picture");
+    const picture = await page.$(".hero picture");
     expect(picture).toExist();
 
-    await page.waitForSelector(".hero-wrapper picture source");
-    const sources = await page.$$(".hero-wrapper picture source");
+    await page.waitForSelector(".hero picture source");
+    const sources = await page.$$(".hero picture source");
     expect(sources.length).toBe(3);
 
-    await page.waitForSelector('.hero-wrapper picture img[loading="eager"]');
-    const img = await page.$('.hero-wrapper picture img[loading="eager"]');
+    await page.waitForSelector('.hero picture img[loading="eager"]');
+    const img = await page.$('.hero picture img[loading="eager"]');
     expect(img).toExist();
   });
 });

--- a/blocks/tabs/tabs.test.js
+++ b/blocks/tabs/tabs.test.js
@@ -4,8 +4,8 @@ describe('Tabs Block', () => {
   });
 
   it('should render the tabs wrapper', async () => {
-    await page.waitForSelector('.tabs-wrapper');
-    const tabsWrapper = await page.$('.tabs-wrapper');
+    await page.waitForSelector('.tabs');
+    const tabsWrapper = await page.$('.tabs');
     expect(tabsWrapper).toExist();
   });
-}); 
+});

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -562,7 +562,7 @@ function decorateBlock(block) {
     block.dataset.blockStatus = 'initialized';
     wrapTextNodes(block);
     const blockWrapper = block.parentElement;
-    blockWrapper.classList.add(`${shortBlockName}-wrapper`);
+    blockWrapper.classList.add(`${shortBlockName}`);
     const section = block.closest('.section');
     if (section) section.classList.add(`${shortBlockName}-container`);
   }

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -557,12 +557,10 @@ async function loadBlock(block) {
 function decorateBlock(block) {
   const shortBlockName = block.classList[0];
   if (shortBlockName) {
-    block.classList.add('block');
+    block.classList.add('block', `${shortBlockName}`);
     block.dataset.blockName = shortBlockName;
     block.dataset.blockStatus = 'initialized';
     wrapTextNodes(block);
-    const blockWrapper = block.parentElement;
-    blockWrapper.classList.add(`${shortBlockName}`);
     const section = block.closest('.section');
     if (section) section.classList.add(`${shortBlockName}-container`);
   }

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -416,7 +416,6 @@ function decorateSections(main) {
         const wrapper = document.createElement('div');
         wrappers.push(wrapper);
         defaultContent = e.tagName !== 'DIV';
-        if (defaultContent) wrapper.classList.add('default-content-wrapper');
       }
       wrappers[wrappers.length - 1].append(e);
     });


### PR DESCRIPTION
## Summary of changes
Removes the `-wrapper` class by default and resolves tests and styling. This makes our code more robust and semantic moving forward. Where wrapper classes are essential, we add them at the block level. 

## Relevant Links
- Story: [ADB-224](https://sparkbox.atlassian.net/browse/ADB-224)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://refactor-wrappers--adobe-design-website--adobe.aem.page/


## Validation
1. Make sure all PR checks have passed.
1. Pull down all related branches.
2. Pull up [this version of the sit](https://refactor-wrappers--adobe-design-website--adobe.aem.page/)e with [deployed main](https://main--adobe-design-website--adobe.aem.page/pattern-library/) - everything should function the same. 
  3. The one standout is the hero, which I did not make a new decorate function just to return the wrapper to it's place. This is because we will not be using full-width heroes in the final version of the design. 
1. Pay special attention to our new blocks: the Button, HR, LinkList, Blockquote, and Filter Button blocks. 
