### PR TITLE
feat: global focus indicator

### DIFF
--- a/blocks/filter-group/filter-group.css
+++ b/blocks/filter-group/filter-group.css
@@ -1,4 +1,4 @@
-/* !important added to override system styles to maintain cutoff 
+/* !important added to override system styles to maintain cutoff
 effect on filter buttons to indicate horizontal scroll */
 .filter-group-wrapper {
   padding-right: 0 !important;
@@ -72,16 +72,9 @@ effect on filter buttons to indicate horizontal scroll */
     opacity: 1;
   }
 
-  /*TODO:Unify Button Focus Styles */
   &:focus-visible {
     background-color: var(--color-background-button-filters-default);
-    outline: 2px solid var(--spectrum-focus-indicator-color);
-    outline-offset: 2px;
     color: inherit;
-  }
-
-  &:focus:not(:focus-visible) {
-    outline: none;
   }
 }
 
@@ -97,17 +90,13 @@ effect on filter buttons to indicate horizontal scroll */
     opacity: 0.9;
   }
 
-  /*TODO:Unify Button Focus Styles */
   &:focus-visible {
     background-color: var(--color-background-button-filters-selected);
-    outline: 2px solid var(--spectrum-focus-indicator-color);
-    outline-offset: 2px;
     color: var(--spectrum-gray-50);
   }
 
   &:focus:not(:focus-visible) {
     background-color: var(--color-background-button-filters-selected);
-    outline: none;
   }
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -33,6 +33,31 @@ body {
   }
 }
 
+/* ** Global Focus Styles ** */
+
+:is(a, button, input, textarea, summary, select) {
+  --outline-size: max(2px, 0.08em);
+  --outline-style: solid;
+  --outline-color: var(--spectrum-focus-indicator-color);
+  --outline-offset: 2px;
+}
+
+:is(a, button, input, textarea, summary, select):focus {
+  outline: var(--outline-size) var(--outline-style) var(--outline-color);
+  outline-offset: var(--outline-offset, var(--outline-size));
+}
+
+:is(a, button, input, textarea, summary, select):focus-visible {
+  outline: var(--outline-size) var(--outline-style) var(--outline-color);
+  outline-offset: var(--outline-offset, var(--outline-size));
+}
+
+:is(a, button, input, textarea, summary, select):focus:not(:focus-visible) {
+  outline: none;
+}
+
+/* ** Performance ** */
+
 body.appear {
   display: block;
 }
@@ -181,12 +206,6 @@ a:hover {
     color: var(--color-button-text-disabled);
     cursor: unset;
   }
-
-  &:focus,
-  &:focus-visible {
-    outline: 2px solid var(--spectrum-focus-indicator-color);
-    outline-offset: 2px;
-  }
 }
 
 .button--primary {
@@ -194,7 +213,7 @@ a:hover {
   --color-button-background-primary-hover: rgb(from var(--spectrum-black) r g b / 93%);
   --color-button-background-primary-disabled: rgb(from var(--spectrum-black) r g b / 9%);
   --color-button-text-primary: var(--spectrum-white);
-  
+
   background-color: var(--color-button-background-primary);
   color: var(--color-button-text-primary);
 
@@ -242,7 +261,7 @@ a:hover {
     background-color: var(--color-button-background-primary-outline-hover);
     color: var(--color-button-text-primary-outline-hover);
   }
-  
+
   &:disabled,
   &:disabled:hover {
     border-color: var(--color-button-border-primary-outline-disabled);
@@ -289,7 +308,7 @@ a:hover {
     background-color: var(--color-button-background-static-black-hover);
     color: var(--color-button-text-static-black-hover);
   }
-  
+
   &:disabled,
   &:disabled:hover {
     border-color: var(--color-button-border-static-black-disabled);
@@ -308,13 +327,13 @@ a:hover {
 
   border: 2px solid var(--color-button-border-static-white);
   color: var(--color-button-text-static-white);
-  
+
   &:hover {
     border-color: var(--color-button-border-static-white-hover);
     background-color: var(--color-button-background-static-white-hover);
     color: var(--color-button-text-static-white-hover);
   }
-  
+
   &:disabled,
   &:disabled:hover {
     border-color: var(--color-button-border-static-white-disabled);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -299,6 +299,7 @@ a:hover {
   --color-button-text-static-black: rgb(from var(--spectrum-black) r g b / 84%);
   --color-button-text-static-black-hover: rgb(from var(--spectrum-black) r g b / 93%);
   --color-button-text-static-black-disabled: rgb(from var(--spectrum-black) r g b / 22%);
+  --outline-color: rgb(from var(--spectrum-black) r g b / 84%);
 
   border: 2px solid var(--color-button-border-static-black);
   color: var(--color-button-text-static-black);
@@ -324,6 +325,7 @@ a:hover {
   --color-button-text-static-white: rgb(from var(--spectrum-white) r g b / 85%);
   --color-button-text-static-white-hover: rgb(from var(--spectrum-white) r g b / 94%);
   --color-button-text-static-white-disabled: rgb(from var(--spectrum-white) r g b / 21%);
+  --outline-color: rgb(from var(--spectrum-white) r g b / 85%);
 
   border: 2px solid var(--color-button-border-static-white);
   color: var(--color-button-text-static-white);


### PR DESCRIPTION
## Summary of changes
- Creates global focus styles
- Removes focus styles from button and filters

## Relevant Links
- Designs: [Figma](https://www.figma.com/design/QzvOszpLGT7fwSd6N7gaDW/Adobe-Design)
- Story: [ADB-186](https://sparkbox.atlassian.net/browse/ADB-186)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://focus-styles--adobe-design-website--adobe.aem.page/


## Validation
1. Use the keyboard to test the focus styles. 
2. Also click stuff