### PR TITLE
feat: two-up layout

### DIFF
--- a/blocks/cards/cards.test.js
+++ b/blocks/cards/cards.test.js
@@ -4,8 +4,8 @@ describe('Cards Block', () => {
   });
 
   it('should render the cards wrapper', async () => {
-    await page.waitForSelector('.cards');
-    const cardsWrapper = await page.$('.cards');
+    await page.waitForSelector('.card');
+    const cardsWrapper = await page.$('.card');
     expect(cardsWrapper).toExist();
   });
 });

--- a/blocks/link-list/link-list.js
+++ b/blocks/link-list/link-list.js
@@ -1,14 +1,15 @@
-const buildLinkListAnchor = ({ textContent, url }) => {
-  const linkListItem = document.createElement('a');
-  linkListItem.className = 'link-list-item';
-  linkListItem.href = url;
+const buildLinkListItem = ({ textContent, url }) => {
+  const linkListItem = document.createElement('li');
+  const linkListItemAnchor = document.createElement('a');
+  linkListItemAnchor.className = 'link-list-item';
+  linkListItemAnchor.href = url;
 
   const linkListItemContent = document.createElement('div');
   linkListItemContent.className = 'link-list-item__content';
-  linkListItem.append(linkListItemContent);
+  linkListItemAnchor.append(linkListItemContent);
 
   if (!url.startsWith('https://adobe.design/')) {
-    linkListItem.classList.add('link-list-item--external');
+    linkListItemAnchor.classList.add('link-list-item--external');
   };
 
   textContent.forEach(textNode => {
@@ -23,36 +24,25 @@ const buildLinkListAnchor = ({ textContent, url }) => {
     linkListItemContent.children[2].className = 'link-list-item__job-location';
   };
 
+  linkListItem.append(linkListItemAnchor);
   return linkListItem;
 };
 
 export default async function decorate(block) {
+  const linkListContainer = document.createElement('div');
   const linkList = document.createElement('ul');
-
-  const linkListTitle = [...block.children][0].children[0].children[0];
-  linkListTitle.className = 'link-list__title';
-
-  let linkListFooterLink = null;
-  if ([...block.children][0].children[1].children.length === 1)
-    linkListFooterLink = [...block.children][0].children[1].children[0].children[0];
-
-  const linkListLinksData = [...block.children].slice(1).map(row => ({
+  linkListContainer.classList.add('link-list');
+  linkListContainer.append(linkList);
+  
+  const linkListLinksData = [...block.children].map(row => ({
     textContent: [...row.children[0].children],
     url: row.children[1].innerText,
   }));
-  linkListLinksData.forEach(row => {
-    const linkListItem = document.createElement('li');
-    const linkListAnchor = buildLinkListAnchor(row);
 
-    linkListItem.append(linkListAnchor);
+  linkListLinksData.forEach(row => {
+    const linkListItem = buildLinkListItem(row);
     linkList.append(linkListItem);
   });
 
-  block.innerHTML = '';
-  block.append(linkListTitle);
-  block.append(linkList);
-  if (linkListFooterLink) {
-    linkListFooterLink.classList.remove('button');
-    block.append(linkListFooterLink);
-  };
-}
+  block.replaceWith(linkListContainer);
+};

--- a/blocks/link-list/link-list.test.js
+++ b/blocks/link-list/link-list.test.js
@@ -9,21 +9,6 @@ describe('Link-List Block', () => {
     expect(linkLists.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('should render the link-list title', async () => {
-    await page.waitForSelector('.link-list__title');
-    const linkListTitles = await page.$$('.link-list__title');
-    expect(linkListTitles.length).toBeGreaterThanOrEqual(1);
-  });
-
-  it('should render the link-list footer link, if it exists', async () => {
-    await page.waitForSelector('.link-list > a');
-    const linkListsWithFooterLink = await page.$$('.link-list > a');
-
-    if (linkListsWithFooterLink) {
-      expect(linkListsWithFooterLink.length).toBeGreaterThanOrEqual(1);
-    };
-  })
-
   describe('Link-List-Item', () => {
     beforeAll(async () => {
       await page.waitForSelector('.link-list-item');

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -362,11 +362,11 @@ function wrapTextNodes(block) {
 function decorateHorizontalRules(element) {
   element.querySelectorAll('p').forEach((p) => {
     const content = p.textContent.trim();
-    if (content === '<hr>' || content === '<hr fw>') {
+    if (content === '-hr-' || content === '-hr fw-') {
       const wrapper = document.createElement('div');
       wrapper.className = 'horizontal-rule-wrapper';
       const hr = document.createElement('hr');
-      hr.className = content === '<hr fw>' ? 'horizontal-rule horizontal-rule--full' : 'horizontal-rule';
+      hr.className = content === '-hr fw-' ? 'horizontal-rule horizontal-rule--full' : 'horizontal-rule';
       wrapper.appendChild(hr);
       p.parentElement.replaceWith(wrapper);
     }

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -379,27 +379,27 @@ function decorateHorizontalRules(element) {
  */
 function decorateLayouts(element) {
   // find all '<layout>' text nodes regardless of layout type
-  const layoutStarters = Array.from(element.querySelectorAll('p'))
-    .filter((p) => p.textContent.trim().startsWith('<layout'));
+  const layoutOpeningTags = Array.from(element.querySelectorAll('p'))
+    .filter((p) => p.textContent.trim().startsWith('-layout'));
 
-  for (const layoutStarter of layoutStarters) {
-    const layoutWrapper = layoutStarter.parentNode;
+  for (const layoutOpeningTag of layoutOpeningTags) {
+    const layoutWrapper = layoutOpeningTag.parentNode;
     let currentElement = layoutWrapper.nextElementSibling;
-    let layoutEnder = null;
+    let layoutClosingTag = null;
     const elementsToContain = [];
 
     while (currentElement) {
-      if (currentElement.textContent.includes('</layout>')) {
+      if (currentElement.textContent.includes('-end layout-')) {
         // ensure only the <p> containing the layout ender is removed at the end of this iteration
         // there may be a layout starter in the same <div>
-        layoutEnder = Array.from(currentElement.querySelectorAll('p'))
-          .find((p) => p.textContent.trim() === '</layout>');
+        layoutClosingTag = Array.from(currentElement.querySelectorAll('p'))
+          .find((p) => p.textContent.trim() === '-end layout-');
         break;
       };
 
       // TODO: support other layout types
       // apply 50/50 layout for two-up
-      if (layoutStarter.textContent.endsWith('two-up>'))
+      if (layoutOpeningTag.textContent.endsWith('two-up-'))
         currentElement.classList.add('grid-item', 'grid-item--50');
 
       elementsToContain.push(currentElement);
@@ -407,15 +407,15 @@ function decorateLayouts(element) {
     };
 
     // only creates a layout container for valid <layout></layout> pairs
-    if (layoutEnder) {
+    if (layoutClosingTag) {
       const layoutContainer = document.createElement('div');
       layoutContainer.className = 'grid-container';
 
       elementsToContain.forEach((e) => layoutContainer.appendChild(e));
       layoutWrapper.after(layoutContainer);
 
-      layoutStarter.remove();
-      layoutEnder.remove();
+      layoutOpeningTag.remove();
+      layoutClosingTag.remove();
     };
   };
 };

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -3,6 +3,7 @@ import {
   loadHeader,
   loadFooter,
   decorateHorizontalRules,
+  decorateLayouts,
   decorateIcons,
   decorateSections,
   decorateBlocks,
@@ -61,10 +62,11 @@ function buildAutoBlocks(main) {
 // eslint-disable-next-line import/prefer-default-export
 export function decorateMain(main) {
   decorateHorizontalRules(main),
-  decorateIcons(main);
-  buildAutoBlocks(main);
-  decorateSections(main);
-  decorateBlocks(main);
+  decorateIcons(main),
+  buildAutoBlocks(main),
+  decorateSections(main),
+  decorateBlocks(main),
+  decorateLayouts(main);
 }
 
 /**

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -559,6 +559,10 @@ main .section.highlight {
 }
 
 /* ** Grid Layout Styles **  */
+main > .section > .grid-container {
+  margin-block: 4rem;
+}
+
 .grid-container {
   max-width: 100%;
 
@@ -572,14 +576,14 @@ main .section.highlight {
     @media (min-width: 22.5rem) {
       display: grid;
       grid-template-columns: repeat(8, [col] 1fr);
-      grid-column-gap: 0.5rem;
-      grid-row-gap: 0.5rem;
+      grid-column-gap: 4rem;
+      grid-row-gap: 4rem;
     }
 
     @media (min-width: 48rem) {
       grid-template-columns: repeat(12, [col] 1fr);
-      grid-column-gap: 1rem;
-      grid-row-gap: 1rem;
+      grid-column-gap: 4rem;
+      grid-row-gap: 4rem;
     }
   }
 }
@@ -587,12 +591,11 @@ main .section.highlight {
 .grid-item {
   min-height: 0;
   min-width: 0;
+  align-self: center;
 }
 
 .grid-item--66 {
-  @media (min-width: 22.5rem) {
-    grid-column: span 4;
-  }
+  grid-column: span 8;
 
   @media (min-width: 48rem) {
     grid-column: span 8;
@@ -608,9 +611,7 @@ main .section.highlight {
 }
 
 .grid-item--33 {
-  @media (min-width: 22.5rem) {
-    grid-column: span 4;
-  }
+  grid-column: span 8;
 
   @media (min-width: 48rem) {
     grid-column: span 4;
@@ -618,9 +619,7 @@ main .section.highlight {
 }
 
 .grid-item--30 {
-  @media (min-width: 22.5rem) {
-    grid-column: span 2;
-  }
+  grid-column: span 4;
 
   @media (min-width: 48rem) {
     grid-column: span 3;
@@ -628,9 +627,7 @@ main .section.highlight {
 }
 
 .grid-item--25 {
-  @media (min-width: 22.5rem) {
-    grid-column: span 2;
-  }
+  grid-column: span 4;
 
   @media (min-width: 48rem) {
     grid-column: span 3;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -600,9 +600,7 @@ main .section.highlight {
 }
 
 .grid-item--50 {
-  @media (min-width: 22.5rem) {
-    grid-column: span 4;
-  }
+  grid-column: span 8;
 
   @media (min-width: 48rem) {
     grid-column: span 6;


### PR DESCRIPTION
## Summary of changes
- Link-List no longer takes a title and an optional link
- `.grid-item--50` takes up the entire grid on screen sizes below tablet size
- `decorateLayouts()` function supports two-up layout
- horizontal rule tags match `-NAME-` pattern

## Relevant Links
- Designs: [Figma](https://www.figma.com/design/QzvOszpLGT7fwSd6N7gaDW/Adobe-Design?node-id=841-5194&t=7bVdF3gMQ6LJqeNY-1) (on the homepage, an example of this layout is the Adobe Design News section, which contains a Link-List and Callout block)
- Story: [ADB-181](https://sparkbox.atlassian.net/browse/ADB-181)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/pattern-library/layouts
- After: https://feat-two-up-layout--adobe-design-website--adobe.aem.page/pattern-library/layouts

## Checklist
* [ ] This PR has visual changes, and has been reviewed by a designer.
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR has new code, so new tests were added or updated, and they pass.
* [ ] This PR affects production code, so it was browser tested (see below).
* [ ] The content of this PR requires documentation, so we added a detailed description of the component's purpose, requirements, quirks, and instructions for use by designers and developers. This includes accessibility information if pertinent.

## Validation
1. Visit the [Layout page on the branch preview](https://feat-two-up-layout--adobe-design-website--adobe.aem.page/pattern-library/layouts)
2. Scroll down to the Two-Up section
3. Verify that both Link-List and Button-Group blocks render as expected
4. Change the browser window size and confirm the layout is responsive
5. Visit the [Pattern Library page on the branch preview](https://feat-two-up-layout--adobe-design-website--adobe.aem.page/pattern-library/)
6. Verify the horizontal rule functionality still behaves as expected

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [x] Firefox
* [x] Chrome
* [ ] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
