### PR TITLE
fix: replace reference to undefined rgb tokens

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -35,24 +35,16 @@
   --spectrum-white: rgb(255 255 255);
   --spectrum-black: rgb(0 0 0);
 
-  --spectrum-transparent-white-100: rgba(var(--spectrum-white-rgb) / 0.11);
-  --spectrum-transparent-white-200: rgb(
-    from var(--spectrum-white) r g b / 0.15
-  );
-  --spectrum-transparent-white-500: rgb(
-    from var(--spectrum-white) r g b / 0.39
-  );
-  --spectrum-transparent-white-900: rgba(var(--spectrum-white-rgb) / 0.94);
+  --spectrum-transparent-white-100: rgb(from var(--spectrum-white) r g b / 0.11);
+  --spectrum-transparent-white-200: rgb(from var(--spectrum-white) r g b / 0.15);
+  --spectrum-transparent-white-500: rgb(from var(--spectrum-white) r g b / 0.39);
+  --spectrum-transparent-white-900: rgb(from var(--spectrum-white) r g b / 0.94);
 
-  --spectrum-transparent-black-300: rgb(
-    from var(--spectrum-black) r g b / 0.15
-  );
-  --spectrum-transparent-black-400: rgb(
-    from var(--spectrum-black) r g b / 0.44
-  );
-  --spectrum-transparent-black-800: rgba(var(--spectrum-black-rgb) / 0.84);
+  --spectrum-transparent-black-300: rgb(from var(--spectrum-black) r g b / 0.15);
+  --spectrum-transparent-black-400: rgb(from var(--spectrum-black) r g b / 0.44);
+  --spectrum-transparent-black-800: rgb(from var(--spectrum-black) r g b / 0.84);
 
-  --spectrum-blue-300: rgba(203 226 254);
+  --spectrum-blue-300: rgb(203 226 254);
   --spectrum-blue-500: rgb(142 185 252);
   --spectrum-blue-800: rgb(75 117 255);
   --spectrum-blue-900: rgb(59 99 251);
@@ -339,15 +331,15 @@
     }
   }
 
-  --spectrum-drop-shadow-color-100: rgba(
+  --spectrum-drop-shadow-color-100: rgb(
     0 0 0 / var(--spectrum-drop-shadow-color-100-opacity)
   );
 
-  --spectrum-drop-shadow-color-200: rgba(
+  --spectrum-drop-shadow-color-200: rgb(
     0 0 0 / var(--spectrum-drop-shadow-color-200-opacity)
   );
 
-  --spectrum-drop-shadow-color-300: rgba(
+  --spectrum-drop-shadow-color-300: rgb(
     0 0 0 / var(--spectrum-drop-shadow-color-300-opacity)
   );
 


### PR DESCRIPTION
## Summary of changes
Fixes the values of a few custom properties in `base.css` that were referencing undefined tokens ending in `-rgb`. Also replaces the legacy `rgba()` alias with `rgb()` in a few locations.

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-rgb-base-tokens--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has code changes, and our linters still pass.

## Validation
1. `base.css` no longer references undefined rgb tokens `--spectrum-white-rgb` and `--spectrum-black-rgb`, and updated values look correct.

---
