### PR TITLE
fix: skip link stays on the page

### DIFF
--- a/blocks-helpers/skipLinks.js
+++ b/blocks-helpers/skipLinks.js
@@ -1,6 +1,6 @@
 export const buildSkipLink = () => {
   const skipToContentLink = document.createElement('a');
-  skipToContentLink.href = "/#main-content";
+  skipToContentLink.href = "#main-content";
   skipToContentLink.classList.add('util-skip-link');
   skipToContentLink.innerText = "Skip to main content";
 


### PR DESCRIPTION
## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-links--adobe-design-website--adobe.aem.page/
