### PR TITLE
feat: page header

### DIFF
--- a/blocks/page-header/page-header.css
+++ b/blocks/page-header/page-header.css
@@ -9,16 +9,12 @@
     gap: 4rem;
   }
 
-  @media (min-width: 80rem) {
-    gap: 2rem;
-  }
-
   .page-header__title {
     margin-block-start: 0;
   }
 
   .page-header__title,
-  .page-header__featured-content {
+  .page-header__byline {
     margin-block-end: 1.5rem;
 
     @media (min-width: 48rem) {
@@ -42,7 +38,7 @@
     }
   }
 
-  .page-header__description--featured {
+  .page-header__description--with-byline {
     @media (min-width: 22.5rem) {
       margin-block-end: 1rem;
     }
@@ -56,11 +52,11 @@
     }
   }
 
-  .page-header__featured-subtitle {
+  .page-header-byline__author {
     margin-block-end: 0.25rem;
   }
 
-  .page-header__featured-description {
+  .page-header-byline__title {
     margin-block-end: 0;
   }
 
@@ -95,7 +91,7 @@
       font-size: var(--spectrum-body-size-l);
     }
 
-    .page-header__description--featured {
+    .page-header__description--with-byline {
       font-size: var(--spectrum-title-size-xxxl);
     }
   }
@@ -109,7 +105,7 @@
       font-size: var(--spectrum-body-size-xl);
     }
 
-    .page-header__description--featured {
+    .page-header__description--with-byline {
       font-size: var(--spectrum-title-size-xl);
     }
   }
@@ -119,7 +115,7 @@
       font-size: var(--spectrum-heading-size-xl);
     }
 
-    .page-header__description--featured {
+    .page-header__description--with-byline {
       font-size: var(--spectrum-title-size-xxl);
     }
   }

--- a/blocks/page-header/page-header.css
+++ b/blocks/page-header/page-header.css
@@ -1,0 +1,126 @@
+.page-header {
+  gap: 2rem;
+
+  @media (min-width: 22.5rem) {
+    gap: 3rem;
+  }
+
+  @media (min-width: 48rem) {
+    gap: 4rem;
+  }
+
+  @media (min-width: 80rem) {
+    gap: 2rem;
+  }
+
+  .page-header__title {
+    margin-block-start: 0;
+  }
+
+  .page-header__title,
+  .page-header__featured-content {
+    margin-block-end: 1.5rem;
+
+    @media (min-width: 48rem) {
+      margin-block-end: 2rem;
+    }
+
+    @media (min-width: 80rem) {
+      margin-block-end: 3rem;
+    }
+  }
+
+  .page-header__description {
+    margin-block-end: 1rem;
+
+    @media (min-width: 22.5rem) {
+      margin-block-end: 1.25rem;
+    }
+
+    @media (min-width: 48rem) {
+      margin-block-end: 2rem;
+    }
+  }
+
+  .page-header__description--featured {
+    @media (min-width: 22.5rem) {
+      margin-block-end: 1rem;
+    }
+
+    @media (min-width: 48rem) {
+      margin-block-end: 1rem;
+    }
+
+    @media (min-width: 80rem) {
+      margin-block-end: 3rem;
+    }
+  }
+
+  .page-header__featured-subtitle {
+    margin-block-end: 0.25rem;
+  }
+
+  .page-header__featured-description {
+    margin-block-end: 0;
+  }
+
+  .page-header__button {
+    margin-block-end: 2rem;
+    width: 100%;
+
+    @media (min-width: 22.5rem) {
+      margin-block-end: 0;
+      width: unset;
+    }
+  }
+
+  .page-header__image img {
+    display: block;
+    max-width: 100%;
+    aspect-ratio: auto;
+    height: auto;
+    border-radius: 1rem;
+  }
+
+}
+
+/* adjust font sizes */
+.page-header {
+  @media (min-width: 22.5rem) {
+    h1 {
+      font-size: var(--spectrum-heading-size-xxl);
+    }
+
+    .page-header__description {
+      font-size: var(--spectrum-body-size-l);
+    }
+
+    .page-header__description--featured {
+      font-size: var(--spectrum-title-size-xxxl);
+    }
+  }
+
+  @media (min-width: 48rem) {
+    h1 {
+      font-size: var(--spectrum-heading-size-xxl);
+    }
+
+    .page-header__description {
+      font-size: var(--spectrum-body-size-xl);
+    }
+
+    .page-header__description--featured {
+      font-size: var(--spectrum-title-size-xl);
+    }
+  }
+
+  @media (min-width: 80rem) {
+    h1 {
+      font-size: var(--spectrum-heading-size-xl);
+    }
+
+    .page-header__description--featured {
+      font-size: var(--spectrum-title-size-xxl);
+    }
+  }
+}

--- a/blocks/page-header/page-header.js
+++ b/blocks/page-header/page-header.js
@@ -1,0 +1,95 @@
+export default async function decorate(block) {
+  // parse data into an object
+  const pageHeaderData = {
+    title: block.children?.[0]?.children?.[0]?.children?.[0]?.textContent?.trim(),
+    image: block.children?.[1]?.children?.[0]?.firstElementChild,
+    description: block.children?.[2]?.children?.[0]?.children?.[0]?.innerHTML,
+    featuredSubtitle: block.children?.[3]?.children?.[0]?.children?.[0]?.textContent?.trim(),
+    featuredDescription: block.children?.[3]?.children?.[1]?.children?.[0]?.textContent?.trim(),
+    anchorNode: block.children?.[4]?.children?.[0]?.firstChild?.firstChild,
+    buttonStyle: block.children?.[4]?.children?.[1]?.children?.[0]?.textContent?.trim().toLowerCase(),
+    altText: block.children?.[4]?.children?.[2]?.children?.[0]?.textContent?.trim(),
+  };
+
+  // create the container element
+  const pageHeader = document.createElement("div");
+  pageHeader.classList.add("page-header", "grid-container");
+
+  const pageHeaderContent = document.createElement("div");
+  pageHeaderContent.classList.add("page-header", "grid-item", "grid-item--50");
+
+  // there should always be a title, so create it as an h1
+  const pageTitle = document.createElement("h1");
+  pageTitle.classList.add("page-header__title", "util-heading-xl");
+  pageTitle.innerText = pageHeaderData.title;
+  pageHeaderContent.append(pageTitle);
+
+  // if there is a description, add it as an h2
+  if (pageHeaderData.description) {
+    const pageDescription = document.createElement("div");
+    pageDescription.classList.add("page-header__description");
+
+    // if there is a featured subtitle, the description uses
+    // a different font class, for visual hierarchy
+    pageHeaderData.featuredSubtitle
+    ? pageDescription.classList.add("util-title-m", "page-header__description--featured")
+    : pageDescription.classList.add("util-body-m");
+
+    pageDescription.innerText = pageHeaderData.description;
+    pageHeaderContent.append(pageDescription);
+  }
+
+  // if there is a an author block, build that
+  if (pageHeaderData.featuredSubtitle) {
+    const featuredSubtitleWrapper = document.createElement("div");
+    featuredSubtitleWrapper.classList.add("page-header__featured-content");
+
+    const featuredSubtitle = document.createElement("div");
+    featuredSubtitle.classList.add("page-header__featured-subtitle", "util-detail-l");
+    featuredSubtitle.innerText = pageHeaderData.featuredSubtitle;
+
+    featuredSubtitleWrapper.append(featuredSubtitle);
+
+    if (pageHeaderData.featuredDescription) {
+      const featuredDescription = document.createElement("div");
+      featuredDescription.classList.add("page-header__featured-description", "util-body-xs");
+      featuredDescription.innerText = pageHeaderData.featuredDescription;
+
+      featuredSubtitleWrapper.append(featuredDescription);
+    }
+
+    pageHeaderContent.append(featuredSubtitleWrapper);
+  }
+
+  // if there's a link, build a button
+  if (pageHeaderData.anchorNode) {
+    const pageHeaderButton = pageHeaderData.anchorNode;
+
+    pageHeaderButton.classList.add(
+      "button",
+      "page-header__button",
+    );
+
+    pageHeaderData.buttonStyle
+      ? pageHeaderButton.classList.add(`button--${pageHeaderData.buttonStyle}`)
+      : pageHeaderButton.classList.add("button--primary");
+
+    if (pageHeaderData.altText) {
+      pageHeaderButton.setAttribute("aria-label", pageHeaderData.altText);
+    }
+
+    pageHeaderContent.append(pageHeaderButton);
+  }
+
+  pageHeader.append(pageHeaderContent);
+
+  // if there is an image, add the appropriate attributes
+  if (pageHeaderData.image) {
+    pageHeaderData.image.classList.add('page-header__image', "grid-item", "grid-item--50");
+    pageHeaderData.image.setAttribute('alt', '');
+    pageHeader.append(pageHeaderData.image);
+  }
+
+  // replace the parent with our new block
+  block.parentElement.replaceWith(pageHeader);
+}

--- a/blocks/page-header/page-header.js
+++ b/blocks/page-header/page-header.js
@@ -4,7 +4,7 @@ export default async function decorate(block) {
     title: block.children?.[0]?.children?.[0]?.children?.[0]?.textContent?.trim(),
     image: block.children?.[1]?.children?.[0]?.firstElementChild,
     description: block.children?.[2]?.children?.[0]?.children?.[0]?.innerHTML,
-    featuredSubtitle: block.children?.[3]?.children?.[0]?.children?.[0]?.textContent?.trim(),
+    byline: block.children?.[3]?.children?.[0]?.children?.[0]?.textContent?.trim(),
     featuredDescription: block.children?.[3]?.children?.[1]?.children?.[0]?.textContent?.trim(),
     anchorNode: block.children?.[4]?.children?.[0]?.firstChild?.firstChild,
     buttonStyle: block.children?.[4]?.children?.[1]?.children?.[0]?.textContent?.trim().toLowerCase(),
@@ -16,7 +16,7 @@ export default async function decorate(block) {
   pageHeader.classList.add("page-header", "grid-container");
 
   const pageHeaderContent = document.createElement("div");
-  pageHeaderContent.classList.add("page-header", "grid-item", "grid-item--50");
+  pageHeaderContent.classList.add("page-header__content", "grid-item", "grid-item--50");
 
   // there should always be a title, so create it as an h1
   const pageTitle = document.createElement("h1");
@@ -29,10 +29,10 @@ export default async function decorate(block) {
     const pageDescription = document.createElement("div");
     pageDescription.classList.add("page-header__description");
 
-    // if there is a featured subtitle, the description uses
+    // if there is a byline, the description uses
     // a different font class, for visual hierarchy
-    pageHeaderData.featuredSubtitle
-    ? pageDescription.classList.add("util-title-m", "page-header__description--featured")
+    pageHeaderData.byline
+    ? pageDescription.classList.add("util-title-m", "page-header__description--with-byline")
     : pageDescription.classList.add("util-body-m");
 
     pageDescription.innerText = pageHeaderData.description;
@@ -40,25 +40,25 @@ export default async function decorate(block) {
   }
 
   // if there is a an author block, build that
-  if (pageHeaderData.featuredSubtitle) {
-    const featuredSubtitleWrapper = document.createElement("div");
-    featuredSubtitleWrapper.classList.add("page-header__featured-content");
+  if (pageHeaderData.byline) {
+    const bylineWrapper = document.createElement("div");
+    bylineWrapper.classList.add("page-header__byline", "page-header-byline");
 
-    const featuredSubtitle = document.createElement("div");
-    featuredSubtitle.classList.add("page-header__featured-subtitle", "util-detail-l");
-    featuredSubtitle.innerText = pageHeaderData.featuredSubtitle;
+    const byline = document.createElement("div");
+    byline.classList.add("page-header-byline__author", "util-detail-l");
+    byline.innerText = pageHeaderData.byline;
 
-    featuredSubtitleWrapper.append(featuredSubtitle);
+    bylineWrapper.append(byline);
 
     if (pageHeaderData.featuredDescription) {
       const featuredDescription = document.createElement("div");
-      featuredDescription.classList.add("page-header__featured-description", "util-body-xs");
+      featuredDescription.classList.add("page-header-byline__title", "util-body-xs");
       featuredDescription.innerText = pageHeaderData.featuredDescription;
 
-      featuredSubtitleWrapper.append(featuredDescription);
+      bylineWrapper.append(featuredDescription);
     }
 
-    pageHeaderContent.append(featuredSubtitleWrapper);
+    pageHeaderContent.append(bylineWrapper);
   }
 
   // if there's a link, build a button

--- a/blocks/page-header/page-header.test.js
+++ b/blocks/page-header/page-header.test.js
@@ -1,0 +1,10 @@
+describe('Page Header Block', () => {
+  beforeAll(async () => {
+    await page.goto(`${global.BASE_URL}`);
+  });
+
+  it('should render the page header element', async () => {
+    const header = await page.$('.page-header');
+    expect(header).toExist();
+  });
+});

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -457,7 +457,11 @@ a:hover {
 
 /* ** Grid Layout Styles **  */
 main > .section > .grid-container {
-  margin-block: 2rem;
+  margin-block: 1.25rem;
+
+  @media (min-width: 22.5rem) {
+    margin-block: 2rem;
+  }
 
   @media (min-width: 48rem) {
     margin-block: 4rem;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -208,9 +208,11 @@ a:hover {
     from var(--spectrum-black) r g b / 9%
   );
   --color-button-text-primary: var(--spectrum-white);
-
   background-color: var(--color-button-background-primary);
   color: var(--color-button-text-primary);
+
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 
   &:hover {
     background-color: var(--color-button-background-primary-hover);
@@ -455,7 +457,11 @@ a:hover {
 
 /* ** Grid Layout Styles **  */
 main > .section > .grid-container {
-  margin-block: 4rem;
+  margin-block: 2rem;
+
+  @media (min-width: 48rem) {
+    margin-block: 4rem;
+  }
 }
 
 .grid-container {


### PR DESCRIPTION
## Summary of changes
- page header component

## Relevant Links
- Designs: [Figma](https://www.figma.com/design/QzvOszpLGT7fwSd6N7gaDW/Adobe-Design)
- Story: [ADB-162](https://sparkbox.atlassian.net/browse/ADB-162)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://page-header--adobe-design-website--adobe.aem.page/


## Validation
1. The page header is easiest to review on the homepage. 
  1. Head to / and see the new heading content. 
  1. Note that the background image will be done in a different ticket. 
1. The page header is also included, with documentation, on the pattern library page.
  1. Review the simpler version of the header to note a change in description text, button style, and button alt text.
1. Let Catherine know she's really cool for figuring this bit out. 
1. For the pages with long body copy as a header, I think we can just use the existing `hero` component, though we may need to adjust font sizes of the h1s? 