### PR TITLE
feat: small screen CTA

### DIFF
--- a/blocks/card/card.css
+++ b/blocks/card/card.css
@@ -4,13 +4,11 @@
 }
 
 .card {
-  --card-color-background: var(--spectrum-white);
-
   display: flex;
   flex-direction: column;
   box-shadow: var(--drop-shadow-emphasized);
   border-radius: 1rem;
-  background-color: var(--card-color-background);
+  background-color: var(--color-background-highlighted-element);
   overflow: hidden;
 
   @container card-container (min-width: 28rem) {
@@ -27,11 +25,6 @@
     text-decoration: underline;
   }
 }
-
-:root:has(#color-scheme:checked) .card {
-  --card-color-background: var(--spectrum-gray-50);
-}
-
 .card__image {
   @container card-container (min-width: 28rem) {
     order: 2;
@@ -53,7 +46,7 @@
   justify-content: center;
   padding: 1.25rem 1rem;
   color: var(--color-text);
-  
+
   @container card-container (min-width: 24rem) {
     min-height: 9rem;
   }
@@ -86,7 +79,7 @@
   @container card-container (min-width: 42rem) {
     font-size: var(--spectrum-font-size-700);
   }
-  
+
   @container card-container (min-width: 48rem) {
     font-size: var(--spectrum-font-size-900);
   }
@@ -104,7 +97,7 @@
   @container card-container (min-width: 42rem) {
     font-size: var(--spectrum-font-size-500);
   }
-  
+
   @container card-container (min-width: 48rem) {
     font-size: var(--spectrum-font-size-600);
   }

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -1,16 +1,7 @@
-:root {
-  --color-background-footer: var(--spectrum-white);
-
-  &:has(#color-scheme:checked) {
-    --color-background-footer: var(--spectrum-gray-50);
-  }
-
-}
-
 .footer-content {
   width: 100%;
   padding: 0;
-  background-color: var(--color-background-footer);
+  background-color: var(--color-background-highlighted-element);
   color: var(--color-text-dark);
   overflow-x: hidden;
 }

--- a/blocks/small-screen-cta/small-screen-cta.css
+++ b/blocks/small-screen-cta/small-screen-cta.css
@@ -1,0 +1,47 @@
+.call-to-action {
+  margin-block-end: 4rem;
+
+  @media (min-width: 48rem) {
+    display: flex;
+    padding: 1.5rem;
+    justify-content: space-between;
+    align-items: center;
+    align-self: stretch;
+    border-radius: var(--spectrum-corner-radius-700);
+    background-color: var(--spectrum-gray-25);
+    box-shadow: var(--drop-shadow-emphasized);
+    margin-block-end: 5rem;
+
+    &:has(#color-scheme:checked) {
+      background-color: var(--spectrum-gray-50);
+    }
+  }
+
+  @media (min-width: 80rem) {
+    padding-block: 2rem;
+  }
+
+  @media (min-width: 105rem) {
+    display: none;
+  }
+}
+
+.call-to-action__description {
+  display: none;
+
+  @media (min-width: 48rem) {
+    display: block
+  }
+
+  @media (min-width: 80rem) {
+    font-size: var(--spectrum-title-size-xxl);
+  }
+}
+
+.call-to-action__button {
+  width: 100%;
+
+  @media (min-width: 48rem) {
+    width: unset;
+  }
+}

--- a/blocks/small-screen-cta/small-screen-cta.css
+++ b/blocks/small-screen-cta/small-screen-cta.css
@@ -8,13 +8,9 @@
     align-items: center;
     align-self: stretch;
     border-radius: var(--spectrum-corner-radius-700);
-    background-color: var(--spectrum-gray-25);
+    background-color: var(--color-background-highlighted-element);
     box-shadow: var(--drop-shadow-emphasized);
     margin-block-end: 5rem;
-
-    &:has(#color-scheme:checked) {
-      background-color: var(--spectrum-gray-50);
-    }
   }
 
   @media (min-width: 80rem) {

--- a/blocks/small-screen-cta/small-screen-cta.js
+++ b/blocks/small-screen-cta/small-screen-cta.js
@@ -1,0 +1,38 @@
+/**
+ * Loads and decorates the small screen CTA.
+ * @function
+ * @param {Element} block The header block element
+ */
+export default async function decorate(block) {
+  const ctaData = {
+    description: block.children?.[0]?.children?.[0]?.textContent.trim(),
+    url: block.children?.[1]?.children?.[0]?.textContent.trim(),
+    anchorLabel: block.children?.[1]?.children?.[1]?.textContent.trim(),
+    altText: block.children?.[1]?.children?.[2]?.textContent.trim(),
+  };
+
+  // create the cta
+  const cta = document.createElement('div');
+  cta.classList.add("call-to-action");
+
+  const ctaDescription = document.createElement('div');
+  ctaDescription.classList.add("util-title-xl", "call-to-action__description");
+  ctaDescription.innerText = ctaData.description;
+  cta.append(ctaDescription);
+
+  // prevents broken links; anchors must have urls and labels
+  if (ctaData.url && ctaData.anchorLabel) {
+    const ctaAnchor= document.createElement('a');
+
+    ctaAnchor.classList.add('button', 'button--accent', "call-to-action__button");
+    ctaAnchor.href = ctaData.url;
+    ctaAnchor.innerText = ctaData.anchorLabel;
+
+    if (ctaAnchor.altText) ctaAnchor.setAttribute('aria-label', ctaAnchor.altText);
+
+    cta.append(ctaAnchor);
+  }
+
+  // replace the parent with our new block
+  block.parentElement.replaceWith(cta);
+}

--- a/blocks/small-screen-cta/small-screen-cta.test.js
+++ b/blocks/small-screen-cta/small-screen-cta.test.js
@@ -1,0 +1,25 @@
+describe('Small Screen CTA Block', () => {
+  beforeAll(async () => {
+    await page.setViewport({ width: 350, height: 1000 });
+    await page.goto(`${global.BASE_URL}pattern-library/`);
+    await page.$('.call-to-action');
+  });
+
+  it('On small screens should render the cta block', async () => {
+    const cta = page.$('.call-to-action');
+    expect(cta).toExist();
+  });
+
+  describe("On large screens", () => {
+    beforeAll(async () => {
+      await page.setViewport({ width: 1500, height: 1000 });
+      await page.goto(`${global.BASE_URL}`);
+      await page.$('#main-content');
+    });
+
+    it("should not render the cta block", async () => {
+      const cta = await page.waitForSelector('.call-to-action', { hidden: true, timeout: 3000 });
+      expect(cta).toBeNull();
+    });
+  });
+});

--- a/styles/base.css
+++ b/styles/base.css
@@ -145,6 +145,7 @@
   /* functional colors */
   --color-background-default: var(--spectrum-gray-50);
   --color-background: var(--color-background-default);
+  --color-background-highlighted-element: var(--spectrum-white);
 
   --color-text: var(--spectrum-gray-800);
   --color-text-dark: var(--spectrum-gray-900);
@@ -154,6 +155,7 @@
 
   &:has(#color-scheme:checked) {
     --color-background-default: var(--spectrum-gray-25);
+    --color-background-highlighted-element: var(--spectrum-gray-50);
 
     --color-text-link: var(--spectrum-blue-800);
     --color-text-link-hover: var(--spectrum-blue-900);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -178,7 +178,7 @@ a:hover {
   align-items: center;
   justify-content: center;
   max-width: 100%;
-  padding: 0.5rem 1.25rem;
+  padding: 0.75rem 1.25rem 0.875rem;
   border: none;
   border-radius: var(--border-radius-button);
   background-color: transparent;


### PR DESCRIPTION
## Summary of changes
- built a CTA for use on the homepage
- buttons were looking a little slim, so helped them with some gains

## Relevant Links
- Designs: [Figma](https://www.figma.com/design/QzvOszpLGT7fwSd6N7gaDW/Adobe-Design)
- Story: [ADB-231](https://sparkbox.atlassian.net/browse/ADB-231)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/pattern-library/
- After: https://small-screen-cta--adobe-design-website--adobe.aem.page/pattern-library/

## Validation
1. Go to the pattern library on the smalllllllest screen ✅ CTA is just a button (it's under "small screen cta" on the pattern library page)
1. Increase to middle size screen ✅ CTA has a background and description now 
1. Increase to larges screen, very very big ✅ no CTA it's outta here like me on thursday morning when PTO hits
