### PR TITLE
chore: nav - fix lint defined before use warnings

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -55,11 +55,13 @@ const buildSmallScreenNav = (nav, homepageLink, pageLinks) => {
   let isPanelOpen = false;
   let removeNavFocusTrap = null;
 
+  let openNavMenu, closeNavMenu, handleEscapeKey;
+
   /**
    * Opens the Navigation Menu.
    * @function
    */
-  const openNavMenu = () => {
+  openNavMenu = () => {
     isPanelOpen = true;
 
     menuButton.setAttribute("aria-expanded", true);
@@ -83,7 +85,7 @@ const buildSmallScreenNav = (nav, homepageLink, pageLinks) => {
    * "close" can be called on escape keydown.
    * @function
    */
-  const closeNavMenu = () => {
+  closeNavMenu = () => {
     isPanelOpen = false;
 
     menuButton.focus();
@@ -107,7 +109,7 @@ const buildSmallScreenNav = (nav, homepageLink, pageLinks) => {
    * Pressing the escape key will close the menu.
    * @function
    */
-  const handleEscapeKey = (e) => {
+  handleEscapeKey = (e) => {
     if (e.key === "Escape") {
       closeNavMenu();
     }


### PR DESCRIPTION
## Summary of changes

Fix "was used before it was defined" warnings in the nav, where three functions are all referencing each other. Changing the order was not possible so this is fixed by declaring the variables first.

Original warning:
```
blocks/header/header.js
   71:40  warning  'closeNavMenu' was used before it was defined     no-use-before-define
   78:42  warning  'handleEscapeKey' was used before it was defined  no-use-before-define
  103:45  warning  'handleEscapeKey' was used before it was defined  no-use-before-define
```

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://chore-lint-defined-before--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR has new code, so new tests were added or updated, and they pass.

## Validation
1. `npm run lint` no longer shows warnings.
2. Nav open/close/esc functionality remains the same.
