### PR TITLE
feat: gradients and theme change, and rounded diamond themes

### DIFF
--- a/assets/themes/shapes.js
+++ b/assets/themes/shapes.js
@@ -1,0 +1,25 @@
+/**
+ * @file SVG strings for the page header backgrounds. 
+ */
+
+export const roundedDiamond = 
+`<svg role="presentation" class="shape-diamond" width="1292" height="895" viewBox="0 0 1292 895" fill="none" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+    <g opacity="0.56">
+        <mask id="mask0_2047_12900" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="-114" width="2823" height="1826">
+            <path d="M1215.13 -59.7343C1329.53 -131.277 1474.47 -131.715 1589.29 -60.8653L2737.73 647.796C2850.2 717.202 2850.39 881.026 2738.07 950.694L1597.22 1658.35C1482.57 1729.46 1337.63 1729.37 1223.08 1658.1L84.5849 949.778C-27.1422 880.258 -27.3458 717.35 84.2443 647.569L1215.13 -59.7343Z" fill="url(#paint0_linear_2047_12900)"/>
+        </mask>
+        <g mask="url(#mask0_2047_12900)">
+            <path d="M1215.11 -59.7343C1329.5 -131.277 1474.44 -131.715 1589.27 -60.8653L2737.7 647.796C2850.17 717.202 2850.36 881.026 2738.04 950.694L1597.2 1658.35C1482.54 1729.46 1337.6 1729.37 1223.05 1658.1L84.557 949.778C-27.17 880.258 -27.3738 717.35 84.2162 647.569L1215.11 -59.7343Z" fill="var(--diamond-fill, #745BFC)"/>
+        </g>
+    </g>
+    <defs>
+        <linearGradient id="paint0_linear_2047_12900" x1="4865.08" y1="798.959" x2="-420.387" y2="496.212" gradientUnits="userSpaceOnUse">
+            <stop/>
+            <stop offset="1" stop-opacity="0"/>
+        </linearGradient>
+    </defs>
+</svg>`;
+
+export const allShapes = {
+    roundedDiamond,
+};

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -55,11 +55,13 @@ const buildSmallScreenNav = (nav, homepageLink, pageLinks) => {
   let isPanelOpen = false;
   let removeNavFocusTrap = null;
 
+  let openNavMenu, closeNavMenu, handleEscapeKey;
+
   /**
    * Opens the Navigation Menu.
    * @function
    */
-  const openNavMenu = () => {
+  openNavMenu = () => {
     isPanelOpen = true;
 
     menuButton.setAttribute("aria-expanded", true);
@@ -83,7 +85,7 @@ const buildSmallScreenNav = (nav, homepageLink, pageLinks) => {
    * "close" can be called on escape keydown.
    * @function
    */
-  const closeNavMenu = () => {
+  closeNavMenu = () => {
     isPanelOpen = false;
 
     menuButton.focus();
@@ -107,7 +109,7 @@ const buildSmallScreenNav = (nav, homepageLink, pageLinks) => {
    * Pressing the escape key will close the menu.
    * @function
    */
-  const handleEscapeKey = (e) => {
+  handleEscapeKey = (e) => {
     if (e.key === "Escape") {
       closeNavMenu();
     }

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -300,17 +300,36 @@ function createOptimizedPicture(
  * Set template (page structure) and theme (page styles).
  */
 function decorateTemplateAndTheme() {
-  const addClasses = (element, classes) => {
+  /**
+   * Add cleaned comma separated classes to an element.
+   * @param {*} element HTML element to add classes to
+   * @param {string} classes CSV class(es)
+   * @param {string} classPrefix 
+   */
+  const addClasses = (element, classes, classPrefix = '') => {
     classes.split(',').forEach((c) => {
-      element.classList.add(toClassName(c.trim()));
+      element.classList.add(classPrefix + toClassName(c.trim()));
     });
   };
+
+  // Add template class(es) to body from metadata.
   const template = getMetadata('template');
-  if (template) addClasses(document.body, template);
+  if (template) {
+    addClasses(document.body, template);
+  }
+
+  // Add theme class(es) to body from metadata.
   const theme = getMetadata('theme');
-  if (theme) addClasses(document.body, theme);
+  if (theme) {
+    document.body.classList.add('theme');
+    addClasses(document.body, theme, 'theme--');
+  }
+
+  // Add page specific color from the metadata in a root level CSS custom property.
   const color = getMetadata('color');
-  if (color) document.querySelector(":root").style.setProperty("--color-background", `var(--${color})`);
+  if (color) {
+    document.querySelector(":root").style.setProperty("--color-background", `var(--${color})`);
+  }
 }
 
 /**

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -11,6 +11,8 @@
  */
 
 /* eslint-env browser */
+import { decorateThemeBackgroundVisuals } from "./modules/themeBackgrounds";
+
 function sampleRUM(checkpoint, data) {
   // eslint-disable-next-line max-len
   const timeShift = () => (window.performance ? window.performance.now() : Date.now() - window.hlx.rum.firstReadTime);
@@ -319,10 +321,12 @@ function decorateTemplateAndTheme() {
   }
 
   // Add theme class(es) to body from metadata.
+  // And add any page background vectors needed for this theme.
   const theme = getMetadata('theme');
   if (theme) {
     document.body.classList.add('theme');
     addClasses(document.body, theme, 'theme--');
+    decorateThemeBackgroundVisuals(theme);
   }
 
   // Add page specific color from the metadata in a root level CSS custom property.

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -11,7 +11,7 @@
  */
 
 /* eslint-env browser */
-import { decorateThemeBackgroundVisuals } from "./modules/themeBackgrounds";
+import { decorateThemeBackgroundVisuals } from "./modules/themeBackgrounds.js";
 
 function sampleRUM(checkpoint, data) {
   // eslint-disable-next-line max-len

--- a/scripts/modules/themeBackgrounds.js
+++ b/scripts/modules/themeBackgrounds.js
@@ -1,0 +1,41 @@
+import { allShapes } from "../../assets/themes/shapes.js";
+import { getMetadata } from "../aem.js";
+
+/**
+ * Adds inline SVGs needed for the different hero page backgrounds within some themes.
+ * Appends a container element containing the SVG elements.
+ * 
+ * These are added as their own elements instead of in `background-image` because their
+ * fill colors are changed with CSS between themes and light/dark.
+ */
+export async function decorateThemeBackgroundVisuals() {
+    const theme = getMetadata('theme');
+    if (!theme) return;
+
+    // Array of SVG strings to load per theme name.
+    const graphicsMapping = {
+        'hero-indigo': [allShapes.roundedDiamond],
+        'hero-green': [allShapes.roundedDiamond],
+    };
+
+    // Return if theme does not need any SVGs.
+    if (!Object.keys(graphicsMapping).includes(theme)) {
+        return;
+    }
+
+    // Create presentation only container that holds SVGs, and append to the body.
+    const backgroundVisuals = document.createElement('div');
+    backgroundVisuals.className = 'bg-visuals';
+    backgroundVisuals.setAttribute('aria-hidden', 'true');
+
+    // Parse the SVG strings and append the necessary SVGs to the container, per theme.
+    const parser = new DOMParser();
+    graphicsMapping[theme].forEach(svgString => {
+        const svgDoc = parser.parseFromString(svgString, "image/svg+xml");
+        const svgElement = svgDoc?.documentElement;
+        if (svgElement) backgroundVisuals.appendChild(svgElement);
+    });
+
+    // Append our container to the body.
+    document.body.appendChild(backgroundVisuals);
+}

--- a/scripts/modules/themeBackgrounds.js
+++ b/scripts/modules/themeBackgrounds.js
@@ -1,5 +1,4 @@
 import { allShapes } from "../../assets/themes/shapes.js";
-import { getMetadata } from "../aem.js";
 
 /**
  * Adds inline SVGs needed for the different hero page backgrounds within some themes.
@@ -7,9 +6,10 @@ import { getMetadata } from "../aem.js";
  * 
  * These are added as their own elements instead of in `background-image` because their
  * fill colors are changed with CSS between themes and light/dark.
+ * 
+ * @param {string} theme - The name of the current theme (as stored in metadata).
  */
-export async function decorateThemeBackgroundVisuals() {
-    const theme = getMetadata('theme');
+export async function decorateThemeBackgroundVisuals(theme) {
     if (!theme) return;
 
     // Array of SVG strings to load per theme name.

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -15,6 +15,7 @@ import {
   loadCSS,
   sampleRUM,
 } from './aem.js';
+import { decorateThemeBackgroundVisuals } from './modules/themeBackgrounds.js';
 
 import {
   debounce
@@ -137,6 +138,9 @@ async function loadLazy(doc) {
   window.addEventListener("resize", debounce(() => reloadHeader(headerElement), 150));
 
   loadFooter(doc.querySelector('footer'));
+
+  // Append any theme background SVGs.
+  decorateThemeBackgroundVisuals();
 }
 
 /**

--- a/styles/base.css
+++ b/styles/base.css
@@ -211,6 +211,7 @@
   );
 
   --gradient-indigo-dark: var(--gradient-indigo-500);
+  --gradient-indigo-dark-start: var(--spectrum-indigo-500);
   --gradient-indigo-light: var(--gradient-indigo-400);
 
   --gradient-multitone: linear-gradient(269deg, #eb1000 -0.72%, #4b75ff 81.56%);
@@ -235,6 +236,7 @@
     );
 
     --gradient-indigo-dark: var(--gradient-indigo-100);
+    --gradient-indigo-dark-start: var(--spectrum-indigo-100);
     --gradient-indigo-light: var(--gradient-indigo-200);
   }
 
@@ -602,6 +604,20 @@
   --page-max-width: 97.5rem;
   --page-constrained-text: 75ch;
   --page-nav-height: 4rem;
+
+  --page-bg-height: 48.813rem;
+  
+  @media (min-width: 48rem) {
+    --page-bg-height: 70.75rem;
+  }
+
+  @media (min-width: 80rem) {
+    --page-bg-height: 36.563rem;
+  }
+
+  @media (min-width: 105rem) {
+    --page-bg-height: 55.938rem;
+  }
 
   /* smallest screens */
   --page-gutters: 1.25rem;

--- a/styles/base.css
+++ b/styles/base.css
@@ -64,6 +64,7 @@
   --spectrum-gray-900: rgb(19 19 19);
   --spectrum-gray-1000: rgb(0 0 0);
 
+  --spectrum-indigo-100: rgb(247 248 255);
   --spectrum-indigo-400: rgb(192 201 255);
   --spectrum-indigo-500: rgb(167 178 255);
   --spectrum-indigo-1000: rgb(99 56 238);
@@ -113,6 +114,7 @@
     --spectrum-gray-900: rgb(242 242 242);
     --spectrum-gray-1000: rgb(255 255 255);
 
+    --spectrum-indigo-100: rgb(30 0 93);
     --spectrum-indigo-400: rgb(62 12 174);
     --spectrum-indigo-500: rgb(79 30 209);
     --spectrum-indigo-1000: rgb(139 141 254);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -895,10 +895,11 @@ main > .section > .grid-container {
 
 /* Theme gradient backgrounds also include a color above the gradient to account for overscroll area underneath the sticky nav. */
 .theme {
+  --nav-height: 64px;
   --page-bg-overscroll-color: var(--color-background);
   --page-background: var(--page-bg-main-gradient), linear-gradient(var(--page-bg-overscroll-color) 0%, var(--page-bg-overscroll-color) 100%);
-  --page-background-position: left top 64px, left top;
-  --page-background-size: 100% calc(var(--page-bg-height) - 64px), 100% 64px;
+  --page-background-position: left top var(--nav-height), left top;
+  --page-background-size: 100% calc(var(--page-bg-height) - var(--nav-height)), 100% var(--nav-height);
 }
 
 /* -- Simple color themes with only a gradient. -- */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -895,11 +895,10 @@ main > .section > .grid-container {
 
 /* Theme gradient backgrounds also include a color above the gradient to account for overscroll area underneath the sticky nav. */
 .theme {
-  --nav-height: 64px;
   --page-bg-overscroll-color: var(--color-background);
   --page-background: var(--page-bg-main-gradient), linear-gradient(var(--page-bg-overscroll-color) 0%, var(--page-bg-overscroll-color) 100%);
-  --page-background-position: left top var(--nav-height), left top;
-  --page-background-size: 100% calc(var(--page-bg-height) - var(--nav-height)), 100% var(--nav-height);
+  --page-background-position: left top var(--page-nav-height), left top;
+  --page-background-size: 100% calc(var(--page-bg-height) - var(--page-nav-height)), 100% var(--page-nav-height);
 }
 
 /* -- Simple color themes with only a gradient. -- */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -12,8 +12,8 @@
 
 body {
   background-color: var(--color-background);
-  background-size: 100% 34.5rem;
-  background-position: top;
+  background-size: var(--page-background-size, 100% var(--page-bg-height, 36.563rem));
+  background-position: var(--page-background-position, top);
   background-repeat: no-repeat;
   background-image: var(--page-background);
   display: none;
@@ -893,30 +893,106 @@ main > .section > .grid-container {
 
 /* ** Page Themes ** */
 
-.theme-green {
-  --page-background: var(--gradient-green);
+/* Theme gradient backgrounds also include a color above the gradient to account for overscroll area underneath the sticky nav. */
+.theme {
+  --page-bg-overscroll-color: var(--color-background);
+  --page-background: var(--page-bg-main-gradient), linear-gradient(var(--page-bg-overscroll-color) 0%, var(--page-bg-overscroll-color) 100%);
+  --page-background-position: left top 64px, left top;
+  --page-background-size: 100% calc(var(--page-bg-height) - 64px), 100% 64px;
 }
 
-.theme-blue {
-  --page-background: var(--gradient-blue);
+/* -- Simple color themes with only a gradient. -- */
+.theme--green {
+  --page-bg-main-gradient: var(--gradient-green);
+  --page-bg-overscroll-color: var(--spectrum-green-300);
 }
 
-.theme-seafoam {
-  --page-background: var(--gradient-seafoam);
+.theme--blue {
+  --page-bg-main-gradient: var(--gradient-blue);
 }
 
-.theme-cyan-500 {
-  --page-background: var(--gradient-cyan-500);
+.theme--seafoam {
+  --page-bg-main-gradient: var(--gradient-seafoam);
 }
 
-.theme-cyan-600 {
-  --page-background: var(--gradient-cyan-600);
+.theme--cyan-500 {
+  --page-bg-main-gradient: var(--gradient-cyan-500);
 }
 
-.theme-indigo-dark {
-  --page-background: var(--gradient-indigo-dark);
+.theme--cyan-600 {
+  --page-bg-main-gradient: var(--gradient-cyan-600);
 }
 
-.theme-indigo-light {
-  --page-background: var(--gradient-indigo-light);
+.theme--indigo-dark {
+  --page-bg-main-gradient: var(--gradient-indigo-dark);
+}
+
+.theme--indigo-light {
+  --page-bg-main-gradient: var(--gradient-indigo-light);
+}
+
+/* -- Main page "hero" themes' with overlaid SVG shapes. -- */
+.bg-visuals {
+  position: absolute;
+  overflow: hidden;
+  z-index: -1;
+  pointer-events: none;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: var(--page-bg-height, 0px);
+
+  /* Blend bottom to background, on top of shapes. */
+  &::after {
+    display: block;
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 225px;
+    background: linear-gradient(180deg, rgb(from var(--color-background) r g b / 0) 0%, var(--color-background) 100%);
+  }
+}
+
+.theme--hero-indigo {
+  --page-bg-overscroll-color: var(--gradient-indigo-dark-start);
+  --page-bg-main-gradient: var(--gradient-indigo-dark);
+  --diamond-fill: rgb(116 91 252);
+
+  &:has(#color-scheme:checked) {
+    --diamond-fill: rgb(99 56 238);
+  }
+}
+
+.theme--hero-green {
+  --page-bg-overscroll-color: var(--spectrum-green-300);
+  --page-bg-main-gradient: var(--gradient-green);
+  --diamond-fill: var(--spectrum-green-600);
+}
+
+.theme--hero-indigo .bg-visuals .shape-diamond,
+.theme--hero-green .bg-visuals .shape-diamond {
+  position: absolute;
+  inset: -57px auto auto -327px;
+  min-height: 100%;
+
+  @media (min-width: 48rem) {
+    inset: -113px -316px auto auto;
+    width: 168%;
+  }
+
+  @media (min-width: 80rem) {
+    inset: -154px -320px auto auto;
+    width: auto;
+  }
+
+  @media (min-width: 105rem) {
+    inset: 0 0 auto auto;
+  }
+
+  @media (min-width: 120rem) {
+    inset: 0 0 auto 32.7%;
+    width: 67.3%;
+  }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -918,5 +918,5 @@ main > .section > .grid-container {
 }
 
 .theme-indigo-light {
-  --page-background: var(--gradient-indigo-dark);
+  --page-background: var(--gradient-indigo-light);
 }


### PR DESCRIPTION
## Summary of changes

### Theme and gradients system changes

Changes to implementation of gradients and themes:
- Theme names no longer need to be prefixed with `theme-` in the content metadata. Theme names from metadata are now automatically prefixed with `theme--` and the generic `theme` class is also added along with it to the body.
- Gradients were previously starting higher up than designed, because of the area underneath the sticky nav. To keep the existing gradients without having to change all of their colors, an overscroll color matching the starting gradient has been added 64px above using a second `linear-gradient`, since this area is visible on scroll bounce.
- SVGs used on the hero background areas can't be used as a URL in a `background-image`, or as an image source, because we need access to change the colors with CSS between both themes and light/dark mode. So a new function was added that creates a presentation only div with the inline SVG shapes needed for that theme.

### Completed background for home and story pack pages

The backgrounds for the home page and story pack pages are now working responsively and in light/dark, using the themes:
- `hero-indigo`
- `hero-green`

Other themes to be added in a followup PR.

## Relevant Links
- Designs: [Figma](https://www.figma.com/design/QzvOszpLGT7fwSd6N7gaDW/Adobe-Design?node-id=2047-12876&p=f&m=dev)
- Story: [ADB-XX](https://sparkbox.atlassian.net/browse/ADB-219)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://feat-gradients-updates--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has visual changes, and has been reviewed by a designer.
* [x] This PR has code changes, and our linters still pass.
* [x] This PR has new code, so new tests were added or updated, and they pass.
* [ ] This PR affects production code, so it was browser tested (see below).
* [ ] This PR has copy changes, so copy was proofread and approved.
* [ ] The content of this PR requires documentation, so we added a detailed description of the component's purpose, requirements, quirks, and instructions for use by designers and developers. This includes accessibility information if pertinent.

## Validation

Compare against the new "Hero" section in Figma, as all of the shapes were recently adjusted for all the breakpoints.

1. Visit the [home page](https://feat-gradients-updates--adobe-design-website--adobe.aem.page/) and example story packs page [design systems](https://feat-gradients-updates--adobe-design-website--adobe.aem.page/ideas/design-systems/).
2. Compare against Hero section in Figma at different breakpoints. You should see the rounded diamond shape that fades at the bottom.
3. Compare against Hero section in Figma at both light and dark mode
4. Make sure to test at the largest 1920px breakpoint and above
---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [x] Firefox
* [x] Chrome
* [x] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
