### PR TITLE
chore: nav - fix lint defined before use warnings

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -55,11 +55,13 @@ const buildSmallScreenNav = (nav, homepageLink, pageLinks) => {
   let isPanelOpen = false;
   let removeNavFocusTrap = null;
 
+  let openNavMenu, closeNavMenu, handleEscapeKey;
+
   /**
    * Opens the Navigation Menu.
    * @function
    */
-  const openNavMenu = () => {
+  openNavMenu = () => {
     isPanelOpen = true;
 
     menuButton.setAttribute("aria-expanded", true);
@@ -83,7 +85,7 @@ const buildSmallScreenNav = (nav, homepageLink, pageLinks) => {
    * "close" can be called on escape keydown.
    * @function
    */
-  const closeNavMenu = () => {
+  closeNavMenu = () => {
     isPanelOpen = false;
 
     menuButton.focus();
@@ -107,7 +109,7 @@ const buildSmallScreenNav = (nav, homepageLink, pageLinks) => {
    * Pressing the escape key will close the menu.
    * @function
    */
-  const handleEscapeKey = (e) => {
+  handleEscapeKey = (e) => {
     if (e.key === "Escape") {
       closeNavMenu();
     }


### PR DESCRIPTION
## Summary of changes

Github's [merge and rebase feature creates unverified commits](https://github.com/orgs/community/discussions/11639), and this repo requires verified commits. So this is the modified last commit so it is signed.

Original commit fix:
Fix "was used before it was defined" linter warnings in the nav, where three functions are all referencing each other.


