### PR TITLE
feat: custom index configuration

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -1,0 +1,23 @@
+version: 1
+
+indices:
+  allpages:
+    include:
+      - '/**'
+    exclude:
+      - /partials/**
+      - /drafts/**
+    target: /query-index.xlsx
+    properties:
+      jobTitle:
+        select: head > meta[name="job-title"]
+        value: |
+          attribute(el, 'content')
+      positionType:
+        select: head > meta[name="position-type"]
+        value: |
+          attribute(el, 'content')
+      jobListing:
+        select: head > meta[name="job-listing"]
+        value: |
+          attribute(el, 'content')


### PR DESCRIPTION
## Summary of changes

**feat: custom index configuration**

Add custom index configuration for query-index, based on the one from the existing site. Only includes properties that are not being pulled in automatically from metadata. Also excludes some directories.

I tested this locally with `aem up --print-index` on a career listing, and it appears to be getting the new fields:
<img width="430" alt="Screenshot 2025-05-30 at 4 52 51 PM" src="https://github.com/user-attachments/assets/d225ea88-6d6c-4af7-bd83-6d16a65d4fdd" />
This just needs to be confirmed post-merge that all the existing automatic data is still coming through properly when the integration runs to update the query-index.

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://feat-custom-index-config--adobe-design-website--adobe.aem.page/

## Validation
1. You can pull down and run `aem up --print-index` and then visit the [career detail]() to see the fields logged out as screenshotted in the description.
2. Additional testing must be done post merge to check data after integration run.

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [ ] Chrome
* [ ] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
