### PR TITLE
feat: add all properties to helix-query config

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -9,15 +9,63 @@ indices:
       - /drafts/**
     target: /query-index.xlsx
     properties:
-      jobTitle:
-        select: head > meta[name="job-title"]
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      publicationDate:
+        select: head > meta[name="publication-date"]
+        value: |
+          attribute(el, 'content')
+      publicationTimestamp:
+        select: head > meta[name="publication-date"]
+        value: |
+          parseTimestamp(attribute(el, 'content'), 'MMMM D, YYYY')
+      author:
+        select: head > meta[name="author"]
+        value: |
+          attribute(el, 'content')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      robots:
+        select: head > meta[name="robots"]
+        value: |
+          attribute(el, 'content')
+      theme:
+        select: head > meta[name="theme"]
+        value: |
+          attribute(el, 'content')
+      tag:
+        select: head > meta[name="tag"]
         value: |
           attribute(el, 'content')
       positionType:
         select: head > meta[name="position-type"]
         value: |
           attribute(el, 'content')
+      department:
+        select: head > meta[name="department"]
+        value: |
+          attribute(el, 'content')
+      location:
+        select: head > meta[name="location"]
+        value: |
+          attribute(el, 'content')
+      jobTitle:
+        select: head > meta[name="job-title"]
+        value: |
+          attribute(el, 'content')
       jobListing:
         select: head > meta[name="job-listing"]
         value: |
           attribute(el, 'content')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')


### PR DESCRIPTION
## Summary of changes
Add all needed properties to the `helix-query.yaml` config, since automatic properties no longer occur once a custom configuration is used.

Renames `date` to `publicationDate` and adds an additional `publicationTimestamp` that parses the timestamp. All articles have their "Publication Date" entered as metadata that is formatted like "June 1, 2025".

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://feat-query-properties--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has code changes, and our linters still pass.

## Validation
- You can pull down and run `aem up --print-index`
- Visit an ideas page (https://github.com/adobe/adobe-design-website/pull/99) to see the fields logged out. The two date fields look correct. As do path, title, image, author, description, tag.
  - Note: lastModified is appearing blank in this testing tool, but I've confirmed its config its exactly the same as the old site and other project configs where it is used; I'm assuming this will be populated when the integration runs but this will have to be confirmed.
- Visit a job listing page and the five job related properties should have data.

Note: additional testing must be done post merge to check data after integration run, and the headers need to be updated for the publication date fields.

---
