### PR TITLE
refactor: move nav and footer content to partials folder

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -11,7 +11,7 @@ import { loadFragment } from '../fragment/fragment.js';
 export default async function decorate(block) {
   // load footer as fragment
   const footerMeta = getMetadata('footer');
-  const footerPath = footerMeta ? new URL(footerMeta, window.location).pathname : '/footer';
+  const footerPath = footerMeta ? new URL(footerMeta, window.location).pathname : '/partials/footer';
   const fragment = await loadFragment(footerPath);
 
   // create the footer from that fragment

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -134,7 +134,7 @@ export default async function decorate(block) {
 
   // load nav content
   const navMeta = getMetadata("nav");
-  const navPath = navMeta ? new URL(navMeta, window.location).pathname : "/nav";
+  const navPath = navMeta ? new URL(navMeta, window.location).pathname : "/partials/nav";
   const fragment = await loadFragment(navPath);
 
   // decorate nav


### PR DESCRIPTION
## Summary of changes

Moves the content for the navigation and footer out of the root and into the `partials` folder. Updates paths in the blocks to pull from this new location.

The existing content was **copied** into the new folder so as to not break anything in its current state. After merge we can delete those duplicate files in the root.

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://refactor-move-partials--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has code changes, and our linters still pass.

## Validation
1. Make sure all PR checks have passed.
2. Pull down and run locally or visit the PR testing URL.
3. The main navigation and footer are appearing.

---
