### PR TITLE
fix: sizing of diamond shape at some breakpoints

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -772,11 +772,13 @@ main > .section > .grid-container {
   @media (min-width: 48rem) {
     inset: -113px -316px auto auto;
     width: 168%;
+    height: calc(100% + 113px);
   }
 
   @media (min-width: 80rem) {
     inset: -154px -320px auto auto;
     width: auto;
+    height: calc(100% + 154px);
   }
 
   @media (min-width: 105rem) {


### PR DESCRIPTION
## Summary of changes
Fix sizing of diamond shape at some breakpoints that was causing it not to extend fully to the bottom of its container, causing a hard line where it is meeting the bottom gradient.

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-diamond-breakpoint--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has visual changes, and has been reviewed by a designer.
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR affects production code, so it was browser tested (see below).

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. Scale down homepage and pattern library viewport and make sure the bottom of the gradient no longer creates a hard line; especially between small and XL breakpoints (for example 1000px wide viewport).

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [x] Firefox
* [x] Chrome
* [ ] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
