### PR TITLE
fix: remove publicationtimestamp from query config

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -21,10 +21,6 @@ indices:
         select: head > meta[name="publication-date"]
         value: |
           attribute(el, 'content')
-      publicationTimestamp:
-        select: head > meta[name="publication-date"]
-        value: |
-          parseTimestamp(attribute(el, 'content'), 'MMMM D, YYYY')
       author:
         select: head > meta[name="author"]
         value: |


### PR DESCRIPTION
## Summary of changes

Remove added field as it is no longer needed due to how the AEM integration imports the publication date string of "publicationDate" and automatically recognizes it as a date (converting it into a DATEVALUE serial number).

---

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-remove-timestamp--adobe-design-website--adobe.aem.page/

