### PR TITLE
fix: link-list behavior

### DIFF
--- a/blocks/link-list/link-list.css
+++ b/blocks/link-list/link-list.css
@@ -19,6 +19,19 @@
   }
 }
 
+.grid-item .link-list {
+  @media (min-width: 48rem) {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    margin-block: 0;
+  
+    > li {
+      flex-grow: 1;
+    }
+  }
+}
+
 .link-list--jobs {
   @media (min-width: 48rem) {
     display: grid;

--- a/blocks/link-list/link-list.css
+++ b/blocks/link-list/link-list.css
@@ -21,18 +21,14 @@
 
 .link-list--jobs {
   @media (min-width: 48rem) {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
     margin-block-end: 2.5rem;
 
     .link-list-item::after {
       background: none;
     }
-  }
-  
-  @media (min-width: 80rem) {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    gap: 2rem;
-    margin-block-end: 3rem;
 
     > li {
       border-top: none;
@@ -41,6 +37,11 @@
     > li:last-of-type {
       border-bottom: none;
     }
+  }
+  
+  @media (min-width: 80rem) {
+    grid-template-columns: 1fr 1fr 1fr;
+    margin-block-end: 3rem;
   }
 }
 
@@ -111,10 +112,6 @@
   }
 
   @media (min-width: 48rem) {
-    margin-block-end: 4rem;
-  }
-
-  @media (min-width: 80rem) {
     --footer-link-color-border: var(--spectrum-transparent-black-800);
     --footer-link-color-border-hover: var(--spectrum-transparent-black-900);
     --footer-link-color-border-disabled: var(--spectrum-transparent-black-300);
@@ -123,7 +120,7 @@
     --footer-link-color-text-hover: var(--spectrum-gray-900);
     --footer-link-color-text-disabled: var(--spectrum-gray-400);
 
-    margin-block-end: 5rem;
+    margin-block-end: 4rem;
     border: 2px solid var(--footer-link-color-border);
     padding: 0.75rem 1.25rem 0.875rem;
     min-width: unset;
@@ -146,13 +143,17 @@
     }
   }
 
+  @media (min-width: 80rem) {
+    margin-block-end: 5rem;
+  }
+
   @media (min-width: 105rem) {
     margin-block-end: 6rem;
   }
 }
 
 :root:has(#color-scheme:checked) .link-list-footer-link {
-  @media (min-width: 80rem) {
+  @media (min-width: 48rem) {
     --footer-link-color-border: var(--spectrum-transparent-white-800);
     --footer-link-color-border-hover: var(--spectrum-transparent-white-900);
     --footer-link-color-border-disabled: var(--spectrum-transparent-white-300);

--- a/blocks/link-list/link-list.js
+++ b/blocks/link-list/link-list.js
@@ -90,7 +90,7 @@ export default async function decorate(block) {
     linkList.append(linkListItem);
   });
 
-  block.replaceWith(linkList);
+  block.parentElement.replaceWith(linkList);
 
   if (footerLinkData.textContent && footerLinkData.url) {
     const footerLink = buildLinkListFooterLink(footerLinkData);


### PR DESCRIPTION
## Summary of changes
- link-list matches height of two-up layout container
- link-list with jobs variant support for two-column in-between layout

## Relevant Links
- Designs: [Figma](https://www.figma.com/design/QzvOszpLGT7fwSd6N7gaDW/Adobe-Design?node-id=841-5194&t=dnWI2iGDhBVC4PPb-1)
- Story: [ADB-242](https://sparkbox.atlassian.net/browse/ADB-242)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-link-list-breakpoints--adobe-design-website--adobe.aem.page/

## Validation
1. Navigate to the homepage on the feature branch
2. Scroll to the "Adobe Design News" section
3. Verify the link-list block matches the height of the callout
4. Scroll to the bottom of the page, to the "Design your career at Adobe" section
5. Verify on a screen size >48rem and <80rem, there is a new layout with two columns of career listings
