### PR TITLE
feat: breakpoint and spacing adjustments

### DIFF
--- a/blocks/article-header/article-header.css
+++ b/blocks/article-header/article-header.css
@@ -19,26 +19,26 @@
     ) {
     max-width: var(--page-constrained-text);
     margin-inline: auto;
-  }
 
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    margin-block-start: var(--spacing-heading-block-start-small-screen);
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      margin-block-start: var(--spacing-heading-block-start-small-screen);
 
-    @media (min-width: 22.5rem) {
-      margin-block-start: var(--spacing-heading-block-start-medium-screen);
-    }
+      @media (min-width: 22.5rem) {
+        margin-block-start: var(--spacing-heading-block-start-medium-screen);
+      }
 
-    @media (min-width: 48rem) {
-      margin-block-start: var(--spacing-heading-block-start-large-screen);
-    }
+      @media (min-width: 48rem) {
+        margin-block-start: var(--spacing-heading-block-start-large-screen);
+      }
 
-    @media (min-width: 80rem) {
-      margin-block-start: var(--spacing-heading-block-start-xl-screen);
+      @media (min-width: 80rem) {
+        margin-block-start: var(--spacing-heading-block-start-xl-screen);
+      }
     }
   }
 }

--- a/blocks/button-group/button-group.css
+++ b/blocks/button-group/button-group.css
@@ -4,12 +4,12 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  width: 100%;
   margin-block-start: 0;
   margin-block-end: var(--spacing-global-block-end-small-screen);
 
   @media (min-width: 22.5rem) {
     margin-block-end: var(--spacing-global-block-end-medium-screen);
+    width: 100%;
   }
 
   @media (min-width: 48rem) {
@@ -17,5 +17,21 @@
     flex-direction: row;
     gap: 1.5rem;
     flex-wrap: wrap;
+  }
+
+  .button {
+    width: 100%;
+  }
+
+  @media (min-width: 22.5rem) {
+    .button + .button {
+      width: unset;
+    }
+  }
+
+  @media (min-width: 48rem) {
+    .button {
+      width: unset;
+    }
   }
 }

--- a/blocks/callout/callout.css
+++ b/blocks/callout/callout.css
@@ -45,15 +45,14 @@
     @container callout-wrapper (min-width: 49rem) {
       margin-block-start: 0;
     }
+    @media (min-width: 48rem) {
+      width: unset;
+    }
   }
 
   @container callout-wrapper (min-width: 35.5rem) {
     padding: 2.5rem;
     gap: 1.25rem;
-
-    .button {
-      width: unset;
-    }
   }
 
   @container callout-wrapper (min-width: 44rem) {

--- a/blocks/callout/callout.css
+++ b/blocks/callout/callout.css
@@ -35,7 +35,6 @@
   -moz-osx-font-smoothing: grayscale;
 
   .button {
-    width: 100%;
     margin-block-start: 1.5rem;
 
     svg {
@@ -44,9 +43,6 @@
 
     @container callout-wrapper (min-width: 49rem) {
       margin-block-start: 0;
-    }
-    @media (min-width: 48rem) {
-      width: unset;
     }
   }
 

--- a/blocks/feature-layout/feature-layout.css
+++ b/blocks/feature-layout/feature-layout.css
@@ -33,7 +33,7 @@
     }
   }
 
-  @media (min-width: 80rem) {
+  @media (min-width: 59rem) {
     padding-block: 6rem;
   }
 
@@ -60,14 +60,14 @@
       margin-block-end: var(--spacing-global-block-end-medium-screen);
     }
 
-    @media (min-width: 80rem) {
+    @media (min-width: 59rem) {
       margin-block-end: var(--spacing-global-block-end-large-screen);
     }
   }
 }
 
 :root:has(#color-scheme:checked) .feature-layout {
-  -webkit-font-smoothing: none;
+  -webkit-font-smoothing: auto;
   -moz-osx-font-smoothing: auto;
 }
 
@@ -84,7 +84,7 @@
   .feature-layout__image {
     grid-column: span 8;
   }
-  
+
   @media (min-width: 48rem) {
     row-gap: 4rem;
 
@@ -97,11 +97,7 @@
     }
   }
 
-  @media (min-width: 100rem) {
-    margin-inline: auto;
-  }
-  
-  @media (min-width: 80rem) {
+  @media (min-width: 59rem) {
     .feature-layout__content {
       grid-column: 2 / 6;
     }
@@ -109,6 +105,10 @@
     .feature-layout__image {
       grid-column: 7 / 12;
     }
+  }
+
+  @media (min-width: 100rem) {
+    margin-inline: auto;
   }
 }
 
@@ -142,7 +142,7 @@
     }
   }
 
-  @media (min-width: 80rem) {
+  @media (min-width: 59rem) {
     margin-block-start: 6rem;
 
     h1, h2, h3, h4, h5, h6 {
@@ -176,7 +176,7 @@
   .feature-layout__image {
     grid-column: span 8;
   }
-  
+
   @media (min-width: 48rem) {
     .feature-layout__content {
       grid-column: span 12;
@@ -186,7 +186,7 @@
       grid-column: span 12;
     }
   }
-  
+
   @media (min-width: 105rem) {
     .feature-layout__content {
       grid-column: span 8;
@@ -203,7 +203,7 @@
     width: 100%;
   }
 
-  @media (min-width: 80rem) {
+  @media (min-width: 59rem) {
     order: 2;
   }
 }
@@ -212,8 +212,8 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  
-  @media (min-width: 80rem) {
+
+  @media (min-width: 59rem) {
     order: 1;
   }
 }

--- a/blocks/feature-layout/feature-layout.js
+++ b/blocks/feature-layout/feature-layout.js
@@ -7,10 +7,10 @@
 
 export default async function decorate (block) {
   const data = {
-    backgroundColor: block.children[0]?.innerText?.trim(),
-    textContent: block.children[1]?.children[0],
-    imageContent: block.children[1]?.children[1],
-    altText: block.children[1]?.children[2]?.innerText?.trim(),
+    backgroundColor: block.children?.[0]?.innerText?.trim(),
+    textContent: block.children?.[1]?.children?.[0],
+    imageContent: block.children?.[1]?.children?.[1],
+    altText: block.children?.[1]?.children?.[2]?.innerText?.trim(),
     primaryVariant: Boolean(block.children[2]?.innerText?.trim()),
   };
 
@@ -29,7 +29,7 @@ export default async function decorate (block) {
     );
   };
 
-  if (data.imageContent?.children[0]) {
+  if (data.imageContent) {
     data.imageContent.classList.add("feature-layout__image");
     if (data.altText) data.imageContent?.setAttribute("alt", data.altText);
     gridContainer.append(data.imageContent);

--- a/blocks/job-list/job-list.css
+++ b/blocks/job-list/job-list.css
@@ -46,13 +46,6 @@
     border-top: 0;
   }
 
-  @media (min-width: 34.5rem) {
-
-    & .job-listing::after {
-      display: none;
-    }
-  }
-
   @media (min-width: 48rem) {
     display: grid;
     grid-template-columns: repeat(2, 1fr);

--- a/blocks/job-list/job-list.css
+++ b/blocks/job-list/job-list.css
@@ -46,7 +46,7 @@
     border-top: 0;
   }
 
-  @media (min-width: 48rem) {
+  @media (min-width: 34.5rem) {
 
     & .job-listing::after {
       display: none;

--- a/blocks/link-list/link-list.css
+++ b/blocks/link-list/link-list.css
@@ -20,12 +20,13 @@
 }
 
 .grid-item .link-list {
+  margin-block: 0;
+
   @media (min-width: 48rem) {
     height: 100%;
     display: flex;
     flex-direction: column;
-    margin-block: 0;
-  
+
     > li {
       flex-grow: 1;
     }
@@ -51,7 +52,7 @@
       border-bottom: none;
     }
   }
-  
+
   @media (min-width: 80rem) {
     grid-template-columns: 1fr 1fr 1fr;
     margin-block-end: 3rem;

--- a/blocks/link-list/link-list.css
+++ b/blocks/link-list/link-list.css
@@ -53,6 +53,12 @@
     }
   }
 
+  @media (min-width: 34.5rem) {
+    & .link-list-item::after {
+      display: none;
+    }
+  }
+
   @media (min-width: 80rem) {
     grid-template-columns: 1fr 1fr 1fr;
     margin-block-end: 3rem;

--- a/blocks/link-list/link-list.js
+++ b/blocks/link-list/link-list.js
@@ -2,7 +2,6 @@ import { isExternalURL } from '../../scripts/helpers/index.js';
 
 /**
  * Creates a decorated set of link list items.
- * @function
  * @param {string} textContent the desired link text
  * @param {string} url the desired link href
  * @param {string} [altText] the link aria-label
@@ -43,7 +42,6 @@ const buildLinkListItem = ({ textContent, url, altText }) => {
 
 /**
  * Creates a link to display below the link list block.
- * @function
  * @param {string} textContent the desired link text
  * @param {string} url the desired link href
  * @param {string} [altText] the link aria-label

--- a/blocks/page-header/page-header.css
+++ b/blocks/page-header/page-header.css
@@ -73,15 +73,6 @@
     margin-block-end: 0;
   }
 
-  .page-header__button {
-    width: 100%;
-
-    @media (min-width: 22.5rem) {
-      margin-block-end: 0;
-      width: unset;
-    }
-  }
-
   .page-header__image {
     height: 100%;
   }

--- a/blocks/page-header/page-header.css
+++ b/blocks/page-header/page-header.css
@@ -13,6 +13,15 @@
     margin-block-end: var(--spacing-global-block-end-large-screen);
   }
 
+  &:not(:has(.page-header__image)) {
+    @media (min-width: 48rem) {
+      .page-header__content.grid-item.grid-item--50 {
+        grid-column: span 12;
+        max-width: var(--page-constrained-text);
+      }
+    }
+  }
+
   .page-header__title {
     margin-block-start: 0;
   }
@@ -65,13 +74,16 @@
   }
 
   .page-header__button {
-    margin-block-end: 2rem;
     width: 100%;
 
     @media (min-width: 22.5rem) {
       margin-block-end: 0;
       width: unset;
     }
+  }
+
+  .page-header__image {
+    height: 100%;
   }
 
   .page-header__image img {

--- a/blocks/recent-ideas/recent-ideas.js
+++ b/blocks/recent-ideas/recent-ideas.js
@@ -42,22 +42,19 @@ const fetchDataAndBuildCards = async (cardsParent, settings) => {
 
         // Build markup.
         filteredArticles.forEach(article => {
-            // Create a grid item for a two-up or four-up layout.
-            const gridItem = document.createElement('div');
-            gridItem.classList.add('grid-item', settings.gridItemClass);
 
             // Create card and append.
             const articleImageUrl = article.image.trim();
             const card = buildCard({
-                img: articleImageUrl ? createOptimizedPicture(articleImageUrl) : '', 
+                img: articleImageUrl ? createOptimizedPicture(articleImageUrl) : '',
                 textContent: [
                     article.title,
                     article.description
-                ], 
+                ],
                 url: article.path.trim(),
             });
-            gridItem.append(card);
-            articleHolder.append(gridItem);
+            card.classList.add('grid-item', settings.gridItemClass);
+            articleHolder.append(card);
         });
         // Append everything within our fragment to this parent.
         cardsParent.append(articleHolder);

--- a/blocks/recent-ideas/recent-ideas.test.js
+++ b/blocks/recent-ideas/recent-ideas.test.js
@@ -2,31 +2,31 @@ describe('Recent Ideas Block', () => {
     beforeAll(async () => {
         await page.goto(`${global.BASE_URL}pattern-library/`);
     });
-    
+
     it('should render the recent ideas block wrapper', async () => {
         const block = await page.waitForSelector('.recent-ideas');
         expect(block).toExist();
     });
 
     it('should render a card, within its wrappers', async () => {
-        const card = await page.waitForSelector('.recent-ideas .grid-item .card-container .card');
+        const card = await page.waitForSelector('.recent-ideas .grid-item.card-container .card');
         expect(card).toExist();
     });
 
     it('should have title text within the card', async () => {
-        const heading = await page.waitForSelector('.recent-ideas .grid-item .card-container .card .card__title');
+        const heading = await page.waitForSelector('.recent-ideas .grid-item.card-container .card .card__title');
         const headingText = await page.evaluate(el => el.textContent.trim(), heading);
         expect(headingText.length).toBeGreaterThan(0);
     });
 
     it('should have description text within the card', async () => {
-        const description = await page.waitForSelector('.recent-ideas .grid-item .card-container .card .card__description');
+        const description = await page.waitForSelector('.recent-ideas .grid-item.card-container .card .card__description');
         const descriptionText = await page.evaluate(el => el.textContent.trim(), description);
         expect(descriptionText.length).toBeGreaterThan(0);
     });
 
     it('should have picture element within the card', async () => {
-        const picture = await page.waitForSelector('.recent-ideas .grid-item .card-container .card picture.card__image');
+        const picture = await page.waitForSelector('.recent-ideas .grid-item.card-container .card picture.card__image');
         expect(picture).toExist();
     });
 });

--- a/blocks/section-header/section-header.css
+++ b/blocks/section-header/section-header.css
@@ -36,5 +36,7 @@ main > .section > .section-header {
   .section-header__description + .section-header__button {
     margin-inline-start: auto;
     grid-column: 9 / span 4;
+    grid-row: 1 / span 2;
+    align-self: end;
   }
 }

--- a/blocks/section-header/section-header.css
+++ b/blocks/section-header/section-header.css
@@ -40,3 +40,24 @@ main > .section > .section-header {
     align-self: end;
   }
 }
+
+.grid-item--66 .section-header,
+.grid-item--50 .section-header {
+  /* styles for when a section header with button is inside a limited grid container */
+
+  @media (min-width: 48rem) {
+    .section-header__heading.grid-item--66,
+    .section-header__description.grid-item--66 {
+      grid-column: span 12;
+      max-width: var(--page-constrained-text);
+    }
+
+    .section-header__description + .section-header__button {
+      margin-inline-start: unset;
+      grid-column: span 12;
+      grid-row: 3;
+      align-self: unset;
+      margin-block-start: 1rem;
+    }
+  }
+}

--- a/blocks/section-header/section-header.js
+++ b/blocks/section-header/section-header.js
@@ -17,7 +17,7 @@ export default async function decorate(block) {
   sectionHeaderData.heading.classList.add(
     "section-header__heading",
     "grid-item",
-    "grid-item--100"
+    "grid-item--66"
   );
   sectionHeader.append(sectionHeaderData.heading);
 

--- a/blocks/small-screen-cta/small-screen-cta.css
+++ b/blocks/small-screen-cta/small-screen-cta.css
@@ -27,7 +27,7 @@
   display: none;
 
   @media (min-width: 41.875rem) {
-    display: block
+    display: block;
   }
 
   @media (min-width: 48rem) {

--- a/blocks/small-screen-cta/small-screen-cta.css
+++ b/blocks/small-screen-cta/small-screen-cta.css
@@ -34,11 +34,3 @@
     font-size: var(--spectrum-title-size-xxl);
   }
 }
-
-.call-to-action__button {
-  width: 100%;
-
-  @media (min-width: 48rem) {
-    width: unset;
-  }
-}

--- a/blocks/small-screen-cta/small-screen-cta.css
+++ b/blocks/small-screen-cta/small-screen-cta.css
@@ -1,9 +1,10 @@
 .call-to-action {
   margin-block-end: 4rem;
 
-  @media (min-width: 48rem) {
+  @media (min-width: 41.875rem) {
     display: flex;
     padding: 1.5rem;
+    column-gap: 1rem;
     justify-content: space-between;
     align-items: center;
     align-self: stretch;
@@ -13,11 +14,11 @@
     margin-block-end: 5rem;
   }
 
-  @media (min-width: 80rem) {
+  @media (min-width: 48rem) {
     padding-block: 2rem;
   }
 
-  @media (min-width: 105rem) {
+  @media (min-width: 80rem) {
     display: none;
   }
 }
@@ -25,11 +26,11 @@
 .call-to-action__description {
   display: none;
 
-  @media (min-width: 48rem) {
+  @media (min-width: 41.875rem) {
     display: block
   }
 
-  @media (min-width: 80rem) {
+  @media (min-width: 48rem) {
     font-size: var(--spectrum-title-size-xxl);
   }
 }

--- a/styles/global-blocks.css
+++ b/styles/global-blocks.css
@@ -32,7 +32,7 @@
   margin-block-end: 0;
 
   + .author-bio {
-    margin-block-start: 1rem;
+    margin-block-start: 3rem;
   }
 
   & .author-meta {

--- a/styles/global-blocks.css
+++ b/styles/global-blocks.css
@@ -183,26 +183,18 @@
     h4,
     h5,
     h6 {
-      margin-block-start: var(
-        --spacing-heading-block-start-small-screen
-      );
+      margin-block-start: var(--spacing-heading-block-start-small-screen);
 
       @media (min-width: 22.5rem) {
-        margin-block-start: var(
-          --spacing-heading-block-start-medium-screen
-        );
+        margin-block-start: var(--spacing-heading-block-start-medium-screen);
       }
 
       @media (min-width: 48rem) {
-        margin-block-start: var(
-          --spacing-heading-block-start-large-screen
-        );
+        margin-block-start: var(--spacing-heading-block-start-large-screen);
       }
 
       @media (min-width: 80rem) {
-        margin-block-start: var(
-          --spacing-heading-block-start-xl-screen
-        );
+        margin-block-start: var(--spacing-heading-block-start-xl-screen);
       }
     }
 
@@ -830,18 +822,19 @@ a.card:hover {
   }
 
   > *:not(.section-header):not(div > .horizontal-rule) {
-      margin-block-end: var(--spacing-global-block-end-small-screen);
+    margin-block-end: var(--spacing-global-block-end-small-screen);
 
-      @media (min-width: 48rem) {
-        margin-block-end: var(--spacing-global-block-end-medium-screen);
-      }
-
-      @media (min-width: 80rem) {
-        margin-block-end: var(--spacing-global-block-end-large-screen);
-      }
+    @media (min-width: 48rem) {
+      margin-block-end: var(--spacing-global-block-end-medium-screen);
     }
 
-  > .grid-container .grid-item:has(.section-header) {
+    @media (min-width: 80rem) {
+      margin-block-end: var(--spacing-global-block-end-large-screen);
+    }
+  }
+
+  > .grid-container .grid-item:has(.section-header),
+  > .grid-container .grid-item:has(.image-with-caption) {
     align-self: center;
   }
 }

--- a/styles/global-blocks.css
+++ b/styles/global-blocks.css
@@ -829,7 +829,7 @@ a.card:hover {
     }
 
     @media (min-width: 105rem) {
-      margin-block-end: var(--spacing-heading-block-start-exlarge-screen);
+      margin-block-end: var(--spacing-heading-block-start-xl-screen);
     }
   }
 
@@ -844,4 +844,8 @@ a.card:hover {
         margin-block-end: var(--spacing-global-block-end-large-screen);
       }
     }
+
+  > .grid-container .grid-item:has(.section-header) {
+    align-self: center;
+  }
 }

--- a/styles/global-blocks.css
+++ b/styles/global-blocks.css
@@ -31,10 +31,6 @@
   margin-block-start: 2rem;
   margin-block-end: 0;
 
-  + .author-bio {
-    margin-block-start: 3rem;
-  }
-
   & .author-meta {
     display: flex;
     gap: 1rem;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -104,7 +104,7 @@ main picture:not([class]) > img:not([class]) {
   align-items: center;
   justify-content: center;
   max-width: 100%;
-  padding: 0.75rem 1.25rem 0.875rem;
+  padding: 0.625rem 1rem 0.6875rem;
   border: none;
   border-radius: var(--border-radius-button);
   background-color: transparent;
@@ -512,6 +512,10 @@ main > .section.small-screen-cta-container > .grid-container {
       grid-column-gap: 1.5rem;
       grid-row-gap: 1.5rem;
     }
+
+    @media (min-width: 80rem) {
+      grid-row-gap: 3.375rem;
+    }
   }
 }
 
@@ -553,6 +557,7 @@ main > .section.small-screen-cta-container > .grid-container {
   min-width: 0;
 
   & .card-container,
+  &.card-container,
   & .card,
   & .callout,
   & .callout-container,
@@ -563,7 +568,8 @@ main > .section.small-screen-cta-container > .grid-container {
 }
 
 .callout-container .grid-item,
-.card-container .grid-item {
+.card-container .grid-item,
+.card-container.grid-item {
   align-self: stretch;
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -565,6 +565,12 @@ main > .section.small-screen-cta-container > .grid-container {
     height: 100%;
     box-sizing: border-box;
   }
+
+  & .image-with-caption {
+    @media (min-width: 48rem) {
+      margin-block: auto;
+    }
+  }
 }
 
 .callout-container .grid-item,

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -103,6 +103,7 @@ main picture:not([class]) > img:not([class]) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 100%;
   max-width: 100%;
   padding: 0.625rem 1rem 0.6875rem;
   border: none;
@@ -116,7 +117,6 @@ main picture:not([class]) > img:not([class]) {
   line-height: 1.3;
   text-align: center;
   text-decoration: none;
-  white-space: nowrap;
   cursor: pointer;
 
   &:hover {
@@ -127,6 +127,15 @@ main picture:not([class]) > img:not([class]) {
   &:disabled:hover {
     color: var(--color-button-text-disabled);
     cursor: unset;
+  }
+
+  @media (min-width: 22.5rem) {
+    width: fit-content;
+    white-space: nowrap;
+  }
+
+  @media (min-width: 48rem) {
+    white-space: nowrap;
   }
 }
 


### PR DESCRIPTION
## Summary of changes

Global
- [x] Review all breakpoints to match designs 

Story Packs
- [x] Make the size of cards stretch again
- [x] Large screen spacing

Homepage
- [x] buttons padding top 10 bottom 11 sides 16 line-height 1.3
- [x] adjust buttons in section header so they align with the bottom of the text by having it span 2 col
- [x] Callout button keys off screen size so unset the width at 22.5rem

Article
- [x] Remove Image margin-block-start within article-content
- [x] Author bio with more than one author needs more spacing between bios
- [x] Pre-footer needs the button under the section header text
- [x] There’s an h4 in this article, it should just be body copy

## Relevant Links
- Designs: [Figma](https://www.figma.com/design/QzvOszpLGT7fwSd6N7gaDW/Adobe-Design)
- Story: [ADB-247](https://sparkbox.atlassian.net/browse/ADB-247)
- Story: [ADB-251](https://sparkbox.atlassian.net/browse/ADB-251)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://breakpoints--adobe-design-website--adobe.aem.page/

## Validation: 
@arnest00 I honestly touched a whole bunch of stuff, go through the list and i'll try to annotate the changes with where to test them 
