### PR TITLE
fix: increase button inline padding

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -105,7 +105,7 @@ main picture:not([class]) > img:not([class]) {
   justify-content: center;
   width: 100%;
   max-width: 100%;
-  padding: 0.625rem 1rem 0.6875rem;
+  padding: 0.625rem 1.25rem 0.6875rem;
   border: none;
   border-radius: var(--border-radius-button);
   background-color: transparent;


### PR DESCRIPTION
## Summary of changes
Increase inline padding on buttons globally from `1.0rem` to `1.25rem`.

## Relevant Links
- Story: [ADB-255](https://sparkbox.atlassian.net/browse/ADB-255)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-button-padding--adobe-design-website--adobe.aem.page/

## Validation
1. Make sure all PR checks have passed.
2. Review buttons in use at https://fix-button-padding--adobe-design-website--adobe.aem.page/ and make sure the padding has increased and nothing looks off.

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [ ] Chrome
* [ ] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
