### PR TITLE
fix: ideas route issues

### DIFF
--- a/blocks/ideas/ideas.js
+++ b/blocks/ideas/ideas.js
@@ -95,7 +95,7 @@ export default function decorate(block) {
       "button--primary",
       "ideas__load-button"
     );
-    loadMoreButton.dataset.defaultText = "Load more ideas";
+    loadMoreButton.dataset.defaultText = "Load more";
     loadMoreButton.dataset.loadingText = "Loading ideas…";
     loadMoreButton.textContent = loadMoreButton.dataset.defaultText;
     loadMoreButton.addEventListener("click", handleLoadMore);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -162,8 +162,9 @@ async function loadLazy(doc) {
   // decorate page-specific components
   // decorate article page
   if (isSubPageOf('ideas')) {
-    const isStoryPackPage = document.head.querySelector("meta[name='page-type']")?.content.trim().toLowerCase() === "story pack";
-    if (!isStoryPackPage) buildArticlePage();
+    const isArticle = Boolean(document.querySelector("main.article-content"));
+    console.log(isArticle);
+    if (isArticle) buildArticlePage();
   };
 
   // decorate careers listing page

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -163,7 +163,6 @@ async function loadLazy(doc) {
   // decorate article page
   if (isSubPageOf('ideas')) {
     const isArticle = Boolean(document.querySelector("main.article-content"));
-    console.log(isArticle);
     if (isArticle) buildArticlePage();
   };
 


### PR DESCRIPTION
## Summary of changes
- update ideas block button label to "Load more"
- run `buildArticlePage()` only on appearance of article-header block

## Relevant Links
- Story: [ADB-262](https://sparkbox.atlassian.net/browse/ADB-262)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-ideas-route--adobe-design-website--adobe.aem.page/

## Validation
1. Navigate to the tag page for "design systems" at [/ideas/design-systems](https://fix-ideas-route--adobe-design-website--adobe.aem.page/ideas/design-systems)
2. Scroll down and verify the updated button label
3. Open the page's associated Sharepoint document - the page should be using the ideas block to fetch articles with the "design systems" tag
4. Navigate to the story pack page for "Designing Design Systems" at [/ideas/designing-design-systems](https://fix-ideas-route--adobe-design-website--adobe.aem.page/ideas/designing-design-systems)
5. Scroll down and verify there is no "Load more" button on the page
6. Open the page's associated Sharepoint document - the page should be using the layout tags with manually-entered cards to be featured on the page
7. Navigate to any article
8. Verify the article renders as expected

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [ ] Chrome
* [ ] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari
