### PR TITLE
feat: remove fetch requests for empty css files

### DIFF
--- a/blocks/button-group/button-group.css
+++ b/blocks/button-group/button-group.css
@@ -1,1 +1,0 @@
-/* button styles, and button-group styles located in global-blocks.css */

--- a/blocks/card/card.css
+++ b/blocks/card/card.css
@@ -1,1 +1,0 @@
-/* styles located in global-blocks.css */

--- a/blocks/constrained-text/constrained-text.css
+++ b/blocks/constrained-text/constrained-text.css
@@ -1,1 +1,0 @@
-/* styles are provided via utility class available in styles.css */

--- a/blocks/fragment/fragment.css
+++ b/blocks/fragment/fragment.css
@@ -1,1 +1,0 @@
-/* stylelint-disable no-empty-source */

--- a/blocks/image-with-caption/image-with-caption.css
+++ b/blocks/image-with-caption/image-with-caption.css
@@ -1,1 +1,0 @@
-/* styles located in styles.css */

--- a/blocks/job-listing/job-listing.css
+++ b/blocks/job-listing/job-listing.css
@@ -1,1 +1,0 @@
-/* styles are located in global-blocks.css */

--- a/blocks/recent-ideas/recent-ideas.css
+++ b/blocks/recent-ideas/recent-ideas.css
@@ -1,1 +1,0 @@
-/* Styles determined by layout grid and card classes located in styles.css and global-blocks.css */

--- a/blocks/search/search.css
+++ b/blocks/search/search.css
@@ -1,1 +1,0 @@
-/* styles located in global-blocks.css */

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -12,6 +12,7 @@
 
 /* eslint-env browser */
 import { decorateThemeBackgroundVisuals } from "./helpers/themeBackgrounds.js";
+import { blocksWithoutCSS } from "./helpers/blockSettings.js";
 
 function sampleRUM(checkpoint, data) {
   // eslint-disable-next-line max-len
@@ -609,7 +610,10 @@ async function loadBlock(block) {
     block.dataset.blockStatus = 'loading';
     const { blockName } = block.dataset;
     try {
-      const cssLoaded = loadCSS(`${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.css`);
+      const cssLoaded = blocksWithoutCSS.includes(blockName)
+        ? Promise.resolve()
+        : loadCSS(`${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.css`);
+
       const decorationComplete = new Promise((resolve) => {
         (async () => {
           try {

--- a/scripts/helpers/blockSettings.js
+++ b/scripts/helpers/blockSettings.js
@@ -1,0 +1,18 @@
+/**
+ * List of blocks that do not have a CSS file.
+ * - Some blocks do not need any custom CSS and use utility classes.
+ * - Some blocks CSS are part of the global style files e.g. global-blocks.css and styles.css
+ * 
+ * Block names included here will have the automatic CSS fetching disabled in loadBlock().
+ */
+export const blocksWithoutCSS = [
+    "button-group",
+    "card",
+    "constrained-text",
+    "fragment",
+    "image-with-caption",
+    "job-listing",
+    "lede",
+    "recent-ideas",
+    "search",
+];

--- a/scripts/helpers/index.js
+++ b/scripts/helpers/index.js
@@ -9,6 +9,7 @@ export { loadArticlePreFooter } from "./loadArticlePreFooter.js";
 export { loadListingPreFooter } from "./loadListingPreFooter.js";
 
 // Building blocks
+export { blocksWithoutCSS } from "./blockSettings.js";
 export { getAuthorData } from "./getAuthorData.js";
 export { getListingMetadata } from "./getListingMetadata.js";
 export { buildAuthorAside } from "./buildAuthorAside.js";


### PR DESCRIPTION
## Summary of changes

Reduces the number of fetch requests by no longer trying to fetch block CSS for blocks that do not have CSS files.
Removes empty CSS files that were only there to prevent loading errors.

📉 Reduces number of CSS file fetch requests on the pattern library by 25%.

**Details:** This creates a block settings array that lists all blocks that do not have CSS files. That list is checked before the load/fetch of the CSS in the `loadBlock()` function. This method isn't ideal but is the best option for a few reasons:

1. We can't check in the browser whether the file exists first, without doing a fetch request. Doing that first would double the fetch requests, which would defeat the purpose.
2. We can't mark a block with a setting or data attribute to say it doesn't have CSS, since we don't have access to how blocks are initially generated, and because the CSS loading is done before the block script (with decorator) file is loaded.

## Relevant Links
- Story: [ADB-256](https://sparkbox.atlassian.net/browse/ADB-256)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://feat-empty-css--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has code changes, and our linters still pass.
* [ ] The content of this PR requires documentation, so we added a detailed description of the component's purpose, requirements, quirks, and instructions for use by designers and developers. This includes accessibility information if pertinent.

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. On the testing link, `Failed to load resource: the server responded with a status of 404 ()` errors do not appear for the missing CSS files.
4. In the network tab, removed empty CSS files (9 of them) are not being requested. Pattern library should show 27 CSS files instead of 36.

---
