### PR TITLE
feat: expand browser support for most colors

### DIFF
--- a/blocks/filter-group/filter-group.css
+++ b/blocks/filter-group/filter-group.css
@@ -91,6 +91,7 @@
 
 .filter-group__button--selected {
   --color-background-button-filters-selected: var(--color-text-dark);
+  --color-background-button-filters-selected--unformatted: 19 19 19;
   background-color: var(--color-background-button-filters-selected);
   color: var(--spectrum-gray-50);
   transition: all var(--spectrum-animation-duration-100) ease;
@@ -102,6 +103,11 @@
 
   @media (hover: hover) {
     &:hover {
+
+      /* from syntax is not always supported, this is a fallback */
+      background-color: rgb(var(--color-background-button-filters-selected--unformatted) / 0.9);
+
+      /* both are needed to elegantly break if color-text-dark changes */
       background-color: rgb(from var(--color-background-button-filters-selected) r g b / 0.9);
       color: var(--spectrum-gray-50);
     }
@@ -115,5 +121,7 @@
   --color-background-button-filters-hover: var(
     --spectrum-transparent-white-500
   );
+
+  --color-background-button-filters-selected--unformatted: 242 242 242;
 }
 

--- a/styles/base.css
+++ b/styles/base.css
@@ -45,34 +45,37 @@
   /* ** COLOR ** */
 
   /* spectrum colors */
-  --spectrum-white: rgb(255 255 255);
-  --spectrum-black: rgb(0 0 0);
 
-  --spectrum-transparent-white-25: rgb(from var(--spectrum-white) r g b / 0);
-	--spectrum-transparent-white-50: rgb(from var(--spectrum-white) r g b / 0.04);
-	--spectrum-transparent-white-75: rgb(from var(--spectrum-white) r g b / 0.07);
-	--spectrum-transparent-white-100: rgb(from var(--spectrum-white) r g b / 0.11);
-	--spectrum-transparent-white-200: rgb(from var(--spectrum-white) r g b / 0.15);
-	--spectrum-transparent-white-300: rgb(from var(--spectrum-white) r g b / 0.17);
-	--spectrum-transparent-white-400: rgb(from var(--spectrum-white) r g b / 0.21);
-	--spectrum-transparent-white-500: rgb(from var(--spectrum-white) r g b / 0.39);
-	--spectrum-transparent-white-600: rgb(from var(--spectrum-white) r g b / 0.51);
-	--spectrum-transparent-white-700: rgb(from var(--spectrum-white) r g b / 0.66);
-	--spectrum-transparent-white-800: rgb(from var(--spectrum-white) r g b / 0.85);
-	--spectrum-transparent-white-900: rgb(from var(--spectrum-white) r g b / 0.94);
+  --spectrum-white--unformatted: 255 255 255;
+  --spectrum-white: rgb(var(--spectrum-white--unformatted));
+  --spectrum-black--unformatted: 0 0 0;
+  --spectrum-black: rgb(var(--spectrum-black--unformatted));
 
-	--spectrum-transparent-black-25: rgb(from var(--spectrum-black) r g b / 0);
-	--spectrum-transparent-black-50: rgb(from var(--spectrum-black) r g b / 0.03);
-	--spectrum-transparent-black-75: rgb(from var(--spectrum-black) r g b / 0.05);
-	--spectrum-transparent-black-100: rgb(from var(--spectrum-black) r g b / 0.09);
-	--spectrum-transparent-black-200: rgb(from var(--spectrum-black) r g b / 0.12);
-	--spectrum-transparent-black-300: rgb(from var(--spectrum-black) r g b / 0.15);
-	--spectrum-transparent-black-400: rgb(from var(--spectrum-black) r g b / 0.22);
-	--spectrum-transparent-black-500: rgb(from var(--spectrum-black) r g b / 0.44);
-	--spectrum-transparent-black-600: rgb(from var(--spectrum-black) r g b / 0.56);
-	--spectrum-transparent-black-700: rgb(from var(--spectrum-black) r g b / 0.69);
-	--spectrum-transparent-black-800: rgb(from var(--spectrum-black) r g b / 0.84);
-	--spectrum-transparent-black-900: rgb(from var(--spectrum-black) r g b / 0.93);
+  --spectrum-transparent-white-25: rgb(var(--spectrum-white--unformatted) / 0);
+	--spectrum-transparent-white-50: rgb(var(--spectrum-white--unformatted) / 0.04);
+	--spectrum-transparent-white-75: rgb(var(--spectrum-white--unformatted) / 0.07);
+	--spectrum-transparent-white-100: rgb(var(--spectrum-white--unformatted) / 0.11);
+	--spectrum-transparent-white-200: rgb(var(--spectrum-white--unformatted) / 0.15);
+	--spectrum-transparent-white-300: rgb(var(--spectrum-white--unformatted) / 0.17);
+	--spectrum-transparent-white-400: rgb(var(--spectrum-white--unformatted) / 0.21);
+	--spectrum-transparent-white-500: rgb(var(--spectrum-white--unformatted) / 0.39);
+	--spectrum-transparent-white-600: rgb(var(--spectrum-white--unformatted) / 0.51);
+	--spectrum-transparent-white-700: rgb(var(--spectrum-white--unformatted) / 0.66);
+	--spectrum-transparent-white-800: rgb(var(--spectrum-white--unformatted) / 0.85);
+	--spectrum-transparent-white-900: rgb(var(--spectrum-white--unformatted) / 0.94);
+
+	--spectrum-transparent-black-25: rgb(var(--spectrum-black--unformatted) / 0);
+	--spectrum-transparent-black-50: rgb(var(--spectrum-black--unformatted) / 0.03);
+	--spectrum-transparent-black-75: rgb(var(--spectrum-black--unformatted) / 0.05);
+	--spectrum-transparent-black-100: rgb(var(--spectrum-black--unformatted) / 0.09);
+	--spectrum-transparent-black-200: rgb(var(--spectrum-black--unformatted) / 0.12);
+	--spectrum-transparent-black-300: rgb(var(--spectrum-black--unformatted) / 0.15);
+	--spectrum-transparent-black-400: rgb(var(--spectrum-black--unformatted) / 0.22);
+	--spectrum-transparent-black-500: rgb(var(--spectrum-black--unformatted) / 0.44);
+	--spectrum-transparent-black-600: rgb(var(--spectrum-black--unformatted) / 0.56);
+	--spectrum-transparent-black-700: rgb(var(--spectrum-black--unformatted) / 0.69);
+	--spectrum-transparent-black-800: rgb(var(--spectrum-black--unformatted) / 0.84);
+	--spectrum-transparent-black-900: rgb(var(--spectrum-black--unformatted) / 0.93);
 
   --spectrum-blue-300: rgb(203 226 254);
   --spectrum-blue-400: rgb(172 207 253);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -99,7 +99,7 @@ main picture:not([class]) > img:not([class]) {
 }
 
 .button {
-  --color-button-text-disabled: rgb(from var(--spectrum-black) r g b / 22%);
+  --color-button-text-disabled: var(--spectrum-transparent-black-400);
   --border-radius-button: 3rem;
   --focus-border-radius: var(--border-radius-button);
 
@@ -1246,7 +1246,7 @@ main > .section.small-screen-cta-container > .grid-container {
       @media (min-width: 105rem) {
         inset: 0 0 auto auto;
       }
-    
+
       @media (min-width: 140rem) {
         width: calc(50dvw + 960px);
       }


### PR DESCRIPTION
## Summary of changes
- Remove `from` rgba syntax from meaningful elements

## Relevant Links
- Story: [ADB-254](https://sparkbox.atlassian.net/browse/ADB-254)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://rgbs--adobe-design-website--adobe.aem.page/

## Validation
1. look at the page backgrounds, those are nice
2. look at the filters buttons on the ideas page and see if those are okay
3. add `disabled` to a button somewhere and see how that's going
5. look for instances of the transparency colors in the codebase, the link list and filter buttons are the main places
6. do it on dark mode or light mode, whichever isn't your normal jam
7. do it all in a second browser, probably safari, she can be a little finicky 

Note: we know there are still `from`s in the background gradients, but they break somewhat elegantly and creating fallbacks would require significant code. 