### PR TITLE
feat: support multiple article tags

### DIFF
--- a/blocks/article-header/article-header.js
+++ b/blocks/article-header/article-header.js
@@ -1,5 +1,4 @@
 import { getMetadata } from '../../scripts/aem.js';
-import { prepURL } from '../../scripts/helpers/index.js';
 
 /**
  * Loads and decorates the article header.
@@ -16,7 +15,6 @@ export default async function decorate(block) {
       block.children?.[1]?.children?.[0]?.children?.[0]?.textContent?.trim(),
     author: getMetadata('author'),
     pubDate: getMetadata('publication-date'),
-    tag: getMetadata('tag'),
     image: block.children?.[2]?.children?.[0]?.firstElementChild,
     caption: block.children?.[2]?.children?.[1]?.innerHTML,
     altText: block.children?.[2]?.children?.[2]?.textContent?.trim(),
@@ -29,17 +27,6 @@ export default async function decorate(block) {
   // constrain the width of text on article pages
   const main = document.querySelector("#main-content");
   main.classList.add("article-content");
-
-  // if there is a tag, add it as an eyebrow
-  // that links to the story packs page
-  if (articleHeaderData.tag) {
-    const eyebrow = document.createElement("a");
-    eyebrow.classList.add("article-header__eyebrow", "util-detail-m");
-    const urlSlug = prepURL(articleHeaderData.tag);
-    eyebrow.href = `/ideas/${urlSlug}`;
-    eyebrow.innerText = articleHeaderData.tag;
-    articleHeader.append(eyebrow);
-  }
 
   // there should always be a title, so create it as an h1
   const pageTitle = document.createElement("h1");

--- a/blocks/filter-group/filter-group-functions.js
+++ b/blocks/filter-group/filter-group-functions.js
@@ -37,7 +37,7 @@ const refreshArticleContent = async (selectedFilters = []) => {
   ideasElement.dataset.isFiltered = selectedFilters.length > 0;
 
   // Fetch articles and replace existing articles in Ideas block.
-  const groupTotal = calculateGroupTotal();
+  const groupTotal = calculateGroupTotal(layoutType === "two-up");
   const fragment = await fetchAndBuildIdeas({
     tagName: selectedFilters,
     maxArticles: initialMaxIdeas(features?.length ?? 0, groupTotal),

--- a/blocks/ideas/ideas-functions.js
+++ b/blocks/ideas/ideas-functions.js
@@ -102,14 +102,15 @@ export const initialMaxIdeas = (totalFeatures, groupTotal) => {
 
 /**
  * Calculate number of cards per grouping, based on screen size.
+ * @param {boolean} isTwoUp Is two-up layout (rather than the default four-up).
  * @returns {number}
  */
-export const calculateGroupTotal = () =>
+export const calculateGroupTotal = (isTwoUp = false) =>
   ({
     sm: 3,
     md: 4,
-    lg: 8,
-    xl: 8,
+    lg: isTwoUp ? 4 : 8,
+    xl: isTwoUp ? 4 : 8,
   }[getCurrentBreakpoint()] || 8);
 
 /**

--- a/blocks/ideas/ideas-functions.js
+++ b/blocks/ideas/ideas-functions.js
@@ -153,10 +153,10 @@ export const handleLoadMore = async (event) => {
   const filtersParent = document.querySelector(".filter-group");
   const layoutType = gridContainer?.dataset?.layoutType;
 
-  // Tag(s) to fetch. Tags in filters, or a set tag from the data attribute if there are no filters (story pack page).
+  // Tag(s) to fetch. Tags in filters, or a set tag from the data attribute if there are no filters (tag page).
   const tagsToFind = filtersParent
     ? getCurrentFiltersArray(filtersParent)
-    : gridContainer?.dataset?.tag ?? "All";
+    : gridContainer?.dataset?.tags.split(",") ?? "All";
 
   // Temporarily disable button while loading.
   updateLoadButtonState(clickedButton, true);

--- a/blocks/ideas/ideas-functions.js
+++ b/blocks/ideas/ideas-functions.js
@@ -88,16 +88,16 @@ export const buildIdeasFeature = (featureContent) => {
 };
 
 /**
- * Determine total number of ideas to load initially.
+ * Determine total number of ideas to load initially, so there are enough
+ * cards to display before and after features.
  * @param {number} totalFeatures Total number of feature sections.
- * @param {number} groupTotal How many cards before a feature and how many additional to fetch on load more.
+ * @param {number} groupTotal How many cards before or after a feature.
  * @returns {number}
  */
 export const initialMaxIdeas = (totalFeatures, groupTotal) => {
-  // At least the groupTotal, if there are no features.
-  if (!totalFeatures) return groupTotal;
-  // Include a set of cards above every feature and below the last feature.
-  return totalFeatures * groupTotal + groupTotal;
+  const minTotalWithFeatures = (totalFeatures + 1) * groupTotal;
+  // Include a larger minimum of 3x the grouping, so the total is never too small.
+  return Math.max(minTotalWithFeatures, groupTotal * 3);
 };
 
 /**

--- a/blocks/ideas/ideas.js
+++ b/blocks/ideas/ideas.js
@@ -68,7 +68,7 @@ export default function decorate(block) {
   });
 
   // How many cards before a feature.
-  const groupTotal = calculateGroupTotal();
+  const groupTotal = calculateGroupTotal(settings.layoutType === "two-up");
 
   // Fetch and add markup for articles, and then add in the features.
   const fetchAndAppend = async () => {

--- a/blocks/ideas/ideas.js
+++ b/blocks/ideas/ideas.js
@@ -13,13 +13,13 @@ import {
  *
  * - Lists recent ideas articles, interspersed with featured sections that are entered in the content.
  * - Includes a load more button for loading the next set of articles.
- * - Can pull in a specific tag, for using this block on the story pack (tag) pages.
+ * - Can pull in specific tag(s), for using this block on the tag pages.
  */
 export default function decorate(block) {
   // Settings from content. Stored in first row with optional second column for the tag.
   const settings = {
     layoutType: block.children?.[0]?.children?.[0]?.textContent?.trim(),
-    tag: block.children?.[0]?.children?.[1]?.textContent?.trim() ?? "All",
+    tags: block.children?.[0]?.children?.[1]?.textContent?.trim() ?? "All",
   };
 
   // Features content, stored in row(s) after the first row.
@@ -43,7 +43,7 @@ export default function decorate(block) {
   gridContainer.classList.add("grid-container", "ideas__grid");
   gridContainer.id = "ideas-grid";
   gridContainer.dataset.layoutType = settings.layoutType;
-  gridContainer.dataset.tag = settings.tag;
+  if (settings.tags != "All") gridContainer.dataset.tags = settings.tags;
   ideasBlock.append(gridContainer);
 
   // Create new features markup.
@@ -73,7 +73,7 @@ export default function decorate(block) {
   // Fetch and add markup for articles, and then add in the features.
   const fetchAndAppend = async () => {
     const fragment = await fetchAndBuildIdeas({
-      tagName: settings.tag,
+      tagName: settings.tags.split(","),
       maxArticles: initialMaxIdeas(features.length, groupTotal),
       gridItemClass:
         settings.layoutType === "two-up" ? "grid-item--50" : "grid-item--25",

--- a/blocks/recent-ideas/recent-ideas.js
+++ b/blocks/recent-ideas/recent-ideas.js
@@ -11,7 +11,7 @@ import { fetchAndBuildIdeas } from "../../scripts/helpers/fetchAndBuildIdeas.js"
 export default function decorate(block) {
     // Block settings from content.
     const settings = {
-        tagName: block.children?.[0]?.children?.[0]?.textContent?.trim() ?? "All",
+        tagName: block.children?.[0]?.children?.[0]?.textContent?.trim().split(",") ?? "All",
         maxArticles: parseInt(block.children?.[1]?.children?.[0]?.textContent?.trim(), 10),
         gridItemClass: block.children?.[2]?.children?.[0]?.textContent?.trim().toLowerCase() === "two-up" ? 'grid-item--50' : 'grid-item--25',
         hasHorizontalScroll: block.children?.[2]?.children?.[1]?.textContent?.trim().toLowerCase() === "scrolling",

--- a/scripts/helpers/buildArticlePage.js
+++ b/scripts/helpers/buildArticlePage.js
@@ -1,17 +1,51 @@
+import { getMetadata } from '../../scripts/aem.js';
 import {
   getAuthorData,
   buildAuthorAside,
   loadArticlePreFooter,
+  prepURL,
 } from "./index.js";
+
+/**
+ * Build list of linked article tags.
+ * @returns {HTMLDivElement|null}
+ */
+const buildArticleTags = () => {
+  const tags = getMetadata('tag');
+  if (!tags) return null;
+
+  const tagsWrapper = document.createElement("aside");
+  tagsWrapper.classList.add("tags-aside");
+
+  const heading = document.createElement("h2");
+  heading.classList.add("util-body-s");
+  heading.textContent = "Tags:";
+  tagsWrapper.append(heading);
+
+  const tagsList = document.createElement("ul");
+  tagsList.classList.add("tags-list");
+  tagsWrapper.append(tagsList);
+
+  const tagsArray = tags.split(',').map(item => item.trim());
+  tagsArray.forEach(tag => {
+    const tagListItem = document.createElement("li");
+    const link = document.createElement("a");
+    link.classList.add("button", "button--tag");
+    const urlSlug = prepURL(tag);
+    link.href = `/ideas/${urlSlug}`;
+    link.innerText = tag;
+    tagListItem.append(link);
+    tagsList.append(tagListItem);
+  });
+
+  return tagsWrapper;
+};
 
 /**
  * Append an author bio and article prefooter with static content to
  * article pages. Also moves main article content to a semantic article
  * element.
- *
- * @return {void}
  */
-
 export const buildArticlePage = async () => {
   if (window.errorCode === "404") return;
 
@@ -25,6 +59,9 @@ export const buildArticlePage = async () => {
   const authorData = await getAuthorData();
   const authorBios = buildAuthorAside(authorData);
   articleElement.append(authorBios);
+
+  const articleTags = buildArticleTags();
+  if (articleTags) articleElement.append(articleTags);
 
   articleBodyContainer.append(articleElement);
 

--- a/scripts/helpers/buildArticlePage.js
+++ b/scripts/helpers/buildArticlePage.js
@@ -7,6 +7,11 @@ import {
 } from "./index.js";
 
 /**
+ * Parent directory for tag pages. Followed by the sluggified name of the tag.
+ */
+const tagsRootDirectory = "/ideas/";
+
+/**
  * Build list of linked article tags.
  * @returns {HTMLDivElement|null}
  */
@@ -32,7 +37,7 @@ const buildArticleTags = () => {
     const link = document.createElement("a");
     link.classList.add("button", "button--tag");
     const urlSlug = prepURL(tag);
-    link.href = `/ideas/${urlSlug}`;
+    link.href = `${tagsRootDirectory}${urlSlug}`;
     link.innerText = tag;
     tagListItem.append(link);
     tagsList.append(tagListItem);

--- a/scripts/helpers/fetchAndBuildIdeas.js
+++ b/scripts/helpers/fetchAndBuildIdeas.js
@@ -36,7 +36,11 @@ export const fetchAndBuildIdeas = async (settings) => {
         const tagsToFind = settings.tagName.map(str => str.trim().toLowerCase());
         if (tagsToFind.length > 0 && tagsToFind[0] != 'all') {
             filteredArticles = filteredArticles.filter(
-                ({ tag }) => tagsToFind.includes(tag.trim().toLowerCase())
+                ({ tag }) => {
+                    // Tag(s) string for article can be one or more tags, comma separated.
+                    const articleTags = tag.split(",").map(item => item.trim().toLowerCase());
+                    return articleTags.some(item => tagsToFind.includes(item));
+                }
             );
         }
 

--- a/styles/global-blocks.css
+++ b/styles/global-blocks.css
@@ -954,3 +954,17 @@ a.card:hover {
     align-self: center;
   }
 }
+
+.tags-list {
+  list-style-type: none;
+  margin: 0.25rem 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+
+  li {
+    padding: 0;
+    margin: 0;
+  }
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -344,6 +344,25 @@ main picture:not([class]) > img:not([class]) {
   }
 }
 
+.button--tag {
+  font-size: var(--spectrum-font-size-200);
+  background-color: var(--spectrum-gray-100);
+  border-radius: var(--spectrum-corner-radius-400);
+  padding: 0.375rem 0.75rem;
+  font-weight: normal;
+  color: var(--spectrum-gray-800);
+
+  &:focus {
+    border-radius: var(--spectrum-corner-radius-400);
+  }
+
+  &:hover,
+  &:focus-visible {
+    background-color: var(--spectrum-gray-200);
+    color: var(--spectrum-gray-900);
+  }
+}
+
 .button--hide-at-medium {
   /* supports change in button location */
   /* review section header styles for detail */


### PR DESCRIPTION
## Summary of changes

Adds support for multiple article tags throughout the various blocks, including the ideas block and recent ideas. Multiple tags can be included separated by commas on an article page, and within the settings for the ideas blocks.

Supports multiple tags on the article pages using the new layout where they appear at buttons below the author bio. This replaces the eyebrow tag link from the top of the article header.

## Relevant Links
- Story: [ADB-260](https://sparkbox.atlassian.net/browse/ADB-260)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://feat-multiple-tags--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has visual changes, and has been reviewed by a designer.
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR has new code, so new tests were added or updated, and they pass.
* [ ] This PR affects production code, so it was browser tested (see below).
* [ ] This PR has copy changes, so copy was proofread and approved.
* [ ] The content of this PR requires documentation, so we added a detailed description of the component's purpose, requirements, quirks, and instructions for use by designers and developers. This includes accessibility information if pertinent.

## Validation
1. Make sure all PR checks have passed.
2. Visit testing link.
3. Confirm multiple tags on articles is not causing any issues and these articles appear where they should on the Ideas page filtering. These tags are applied in the metadata of the articles, separated by commas:
    Example Article 17: design systems, design strategy
    Example Article 18: design systems, design leadership, design process
4. Confirm the Ideas block and Recent ideas block work with a tag setting that defines multiple tags separated by a comma. I've set up a testing page for this: /ideas/tags-test . Existing usage with a single tag should also continue to function.
5. Confirm new tags layout on article pages with single tag and multiple tags. See multiple tags on /ideas/example-article-18
---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [x] Chrome
* [x] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
