### PR TITLE
feat: recent ideas - option to pull tags from metadata

### DIFF
--- a/blocks/recent-ideas/recent-ideas.js
+++ b/blocks/recent-ideas/recent-ideas.js
@@ -1,5 +1,5 @@
 import { getMetadata } from "../../scripts/aem.js";
-import { fetchAndBuildIdeas } from "../../scripts/helpers/fetchAndBuildIdeas.js";
+import { fetchAndBuildIdeas } from "../../scripts/helpers/index.js";
 
 /*
  * Recent Ideas Block

--- a/blocks/recent-ideas/recent-ideas.js
+++ b/blocks/recent-ideas/recent-ideas.js
@@ -1,3 +1,4 @@
+import { getMetadata } from "../../scripts/aem.js";
 import { fetchAndBuildIdeas } from "../../scripts/helpers/fetchAndBuildIdeas.js";
 
 /*
@@ -11,11 +12,18 @@ import { fetchAndBuildIdeas } from "../../scripts/helpers/fetchAndBuildIdeas.js"
 export default function decorate(block) {
     // Block settings from content.
     const settings = {
-        tagName: block.children?.[0]?.children?.[0]?.textContent?.trim().split(",") ?? "All",
+        tagName: block.children?.[0]?.children?.[0]?.textContent?.trim().split(",") ?? ["All"],
         maxArticles: parseInt(block.children?.[1]?.children?.[0]?.textContent?.trim(), 10),
         gridItemClass: block.children?.[2]?.children?.[0]?.textContent?.trim().toLowerCase() === "two-up" ? 'grid-item--50' : 'grid-item--25',
         hasHorizontalScroll: block.children?.[2]?.children?.[1]?.textContent?.trim().toLowerCase() === "scrolling",
     };
+
+    // Special case tag name; get tags from page metadata or fall back to "All". 
+    // Used for finding related stories to an article.
+    if (settings.tagName?.[0]?.trim() === "UseMetadataTags") {
+        const metadataTags = getMetadata("tag");
+        settings.tagName = metadataTags ? metadataTags.split(",") : ["All"];
+    }
 
     // Create a new container to house the block.
     const newBlock = document.createElement('div');

--- a/scripts/helpers/fetchAndBuildIdeas.js
+++ b/scripts/helpers/fetchAndBuildIdeas.js
@@ -44,6 +44,9 @@ export const fetchAndBuildIdeas = async (settings) => {
             );
         }
 
+        // Exclude the current path, so we don't show the same article on an article page.
+        filteredArticles = filteredArticles.filter(item => item?.path !== window.location.pathname);
+
         // Sort by published date (serial number or timestamp), with the latest dates first.
         filteredArticles = filteredArticles.sort((a, b) => parseInt(b.publishedDate, 10) - parseInt(a.publishedDate, 10));
 


### PR DESCRIPTION
## Summary of changes

Add an optional value for the Recent Ideas block of "UseMetadataTags", for it to pull in the tags value from the current article page. Used for the article prefooter to show related stories/ideas. Also excludes the current page from list of fetched articles, so the same article you are on does not show in the list of related articles.

The article prefooter content has been updated to use this and the recent ideas block, instead of a manually entered card list.

## Relevant Links
- Story: [ADB-259](https://sparkbox.atlassian.net/browse/ADB-259)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://feat-related-prefooter--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has visual changes, and has been reviewed by a designer.
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR has new code, so new tests were added or updated, and they pass.
* [ ] This PR affects production code, so it was browser tested (see below).
* [ ] This PR has copy changes, so copy was proofread and approved.
* [ ] The content of this PR requires documentation, so we added a detailed description of the component's purpose, requirements, quirks, and instructions for use by designers and developers. This includes accessibility information if pertinent.

## Validation
1. Make sure all PR checks have passed.
2. Visit multiple article pages on the PR testing link.
3. Confirm that ideas with the same tag(s) are appearing in the prefooter related stories.
4. Confirm that the content is using the recent ideas block.

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [x] Chrome
* [ ] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
