### PR TITLE
fix: placeholder rows are not removed prior to block decoration

### DIFF
--- a/blocks/button-group/button-group.js
+++ b/blocks/button-group/button-group.js
@@ -3,7 +3,7 @@ export default async function decorate(block) {
     anchorNode: row.children?.[0]?.firstChild?.firstChild,
     buttonStyle: row.children?.[1]?.firstChild?.innerText.trim(),
     altText: row.children?.[2]?.firstChild?.innerText.trim(),
-    hideButtonOnLargeScreens: row.children?.[3]?.firstChild?.innerText.trim(),
+    hideButtonOnLargeScreens: row.children?.[3]?.firstChild?.innerText,
   }));
 
   const buttonGroupContainer = document.createElement("div");

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -307,7 +307,7 @@ function decorateTemplateAndTheme() {
    * Add cleaned comma separated classes to an element.
    * @param {*} element HTML element to add classes to
    * @param {string} classes CSV class(es)
-   * @param {string} classPrefix 
+   * @param {string} classPrefix
    */
   const addClasses = (element, classes, classPrefix = '') => {
     classes.split(',').forEach((c) => {
@@ -667,7 +667,9 @@ function decorateBlocks(main) {
 function cleanEmptyDivs(main) {
   main.querySelectorAll('div').forEach((div) => {
     const isEmpty = !div.textContent.trim() && div.children.length === 0;
-    if (isEmpty) {
+    const hasAriaLive = div.hasAttribute('aria-live');
+    const hasClass = div.hasAttribute('class') && div.getAttribute('class').trim() !== '';
+    if (isEmpty && !hasAriaLive && !hasClass) {
       div.remove();
     }
   });

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -78,8 +78,7 @@ export function decorateMain(main) {
   buildAutoBlocks(main),
   decorateSections(main),
   decorateBlocks(main),
-  decorateLayouts(main),
-  cleanEmptyDivs(main);
+  decorateLayouts(main);
 }
 
 /**
@@ -174,11 +173,12 @@ async function loadLazy(doc) {
   if (window.location.pathname === "/pattern-library/site-content") buildSiteContentPage();
 
   // supports rerendering of the responsive navigation
-  const headerElement = doc.querySelector('header'); 
+  const headerElement = doc.querySelector('header');
   window.addEventListener("resize", debounce(() => reloadHeader(headerElement, true), 150));
 
   // loads the footer component, along with its stylesheet
   loadFooter(doc.querySelector('footer'));
+  cleanEmptyDivs(main);
 }
 
 /**


### PR DESCRIPTION
## Summary of changes
- Adjust the function order to ensure blocks are fully decorated prior to cleaning up empty DOM elements
- Added a potentially unnecessary check to ensure we don't remove our aria-live region

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://quick-fix--adobe-design-website--adobe.aem.page/


## Validation
1. Review the "view all" buttons on the homepage and check that all buttons work as intended
1. Review the "button group" on the pattern library and check that all buttons work as intended
1. Take a breath to wish we had visual regression testing to catch this stuff 
1. Check that there's always an aria-live region on the page
1. Look out for stray divs
1. Make sure I didn't break your stuff, buddy


