### PR TITLE
feat: recent ideas block fallback for empty state

### DIFF
--- a/blocks/recent-ideas/recent-ideas.js
+++ b/blocks/recent-ideas/recent-ideas.js
@@ -35,7 +35,13 @@ export default function decorate(block) {
 
     // Fetch and add markup for articles (async).
     const fetchAndAppend = async () => {
-        const fragment = await fetchAndBuildIdeas(settings);
+        let fragment = await fetchAndBuildIdeas(settings);
+
+        // If no articles are found, fall back to fetching to "All" instead of a null state.
+        if (!fragment.hasChildNodes() && settings.tagName?.[0]?.trim().toLowerCase() !== "all") {
+            fragment = await fetchAndBuildIdeas({ ...settings, tagName: ["All"] });
+        }
+
         newBlock.append(fragment);
     };
     fetchAndAppend();


### PR DESCRIPTION
## Summary of changes

**Feature: recent ideas block - fallback to all articles if empty**
Add sa fallback to the recent ideas block to handle the empty state when there are no other articles returned. This could occur if an article is the first with a tag, and it is displaying related articles. Instead of showing nothing, it will now pull from all tags.

## Relevant Links
- Story: [ADB-259](https://sparkbox.atlassian.net/browse/ADB-259) (related follow-up)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-recent-ideas-null-state--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR has new code, so new tests were added or updated, and they pass.
* [ ] This PR affects production code, so it was browser tested (see below).
* [ ] The content of this PR requires documentation, so we added a detailed description of the component's purpose, requirements, quirks, and instructions for use by designers and developers. This includes accessibility information if pertinent.

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. The "Building with everyone is just building better" article which is the only with its tag and shows no related stories on main now shows a list of the most recent stories in all tags as a fallback.
4. Other articles' recent stories and homepage ideas block(s) continue to function normally.

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [x] Chrome
* [x] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
