### PR TITLE
feat: prefooter refinement with breakpoint specific careers blocks

### DIFF
--- a/blocks/ideas/ideas.css
+++ b/blocks/ideas/ideas.css
@@ -126,7 +126,6 @@
     border-top: 1px solid var(--spectrum-gray-400);
     border-bottom: 1px solid var(--spectrum-gray-400);
     padding-block: 1rem;
-    margin-block-start: 1rem;
 
     & ~ .grid-item[data-added="true"] {
       border-top: none;

--- a/blocks/ideas/ideas.css
+++ b/blocks/ideas/ideas.css
@@ -120,7 +120,7 @@
 }
 
 /* Appended cards on mobile display differently, including a side-by-side layout. */
-@media (max-width: 31.9999rem) {
+@media not all and (min-width: 32rem) {
   .ideas .grid-item[data-added="true"] {
     grid-column: span 8;
     border-top: 1px solid var(--spectrum-gray-400);

--- a/scripts/helpers/getCurrentBreakpoint.js
+++ b/scripts/helpers/getCurrentBreakpoint.js
@@ -2,9 +2,9 @@
  * Breakpoint ranges. Should match what is used in the CSS.
  */
 const breakpointQueries = [
-  ['sm', '(max-width: 47.9999rem)'],
-  ['md', '(min-width: 48rem) and (max-width: 79.9999rem)'],
-  ['lg', '(min-width: 80rem) and (max-width: 104.9999rem)'],
+  ['sm', '(max-width: 47.999rem)'],
+  ['md', '(min-width: 48rem) and (max-width: 79.999rem)'],
+  ['lg', '(min-width: 80rem) and (max-width: 104.999rem)'],
   ['xl', '(min-width: 105rem)']
 ];
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -799,6 +799,24 @@ main > .section.small-screen-cta-container > .grid-container {
   }
 }
 
+.util-hide-at-medium {
+  @media (min-width: 48rem) {
+    display: none;
+  }
+}
+
+.util-hide-until-large {
+  @media not all and (min-width: 80rem) {
+    display: none;
+  }
+}
+
+.util-hide-until-medium {
+  @media not all and (min-width: 48rem) {
+    display: none;
+  }
+}
+
 /* **  Utilities - Typography ** */
 
 .util-heading-xxl {


### PR DESCRIPTION
## Summary of changes

Addition to layouts to allow for groups of different Careers blocks in the prefooter that are shown/hidden at a breakpoint. Adds a "full" layout name, along with `hide-at-medium` and `hide-until-medium` layout modifiers.

## Relevant Links
- Story: [ADB-253](https://sparkbox.atlassian.net/browse/ADB-253)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://feat-prefooter-refinement--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has visual changes, and has been reviewed by a designer.
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR has new code, so new tests were added or updated, and they pass.
* [ ] This PR affects production code, so it was browser tested (see below).
* [ ] This PR has copy changes, so copy was proofread and approved.
* [ ] The content of this PR requires documentation, so we added a detailed description of the component's purpose, requirements, quirks, and instructions for use by designers and developers. This includes accessibility information if pertinent.

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. Article prefooter careers section shows two different set of blocks at the medium breakpoint, matching design. At medium and above, the blocks with the image on the right appears. At below medium, the linked list with a list of careers appears.
4. Other small fix; ideas mobile load more articles no longer have a messed up padding like this: <img width="459" alt="Screenshot 2025-07-02 at 1 33 14 PM" src="https://github.com/user-attachments/assets/c90d5acd-dc66-4bc8-b6f4-1be93fa6ffbd" />

---



## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [ ] Chrome
* [ ] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
