### PR TITLE
fix: clear up some tests that sometimes fail

### DIFF
--- a/blocks/fragment/fragment.test.js
+++ b/blocks/fragment/fragment.test.js
@@ -3,7 +3,7 @@ describe('Fragment Block', () => {
     await page.goto(`${global.BASE_URL}pattern-library/`);
   });
 
-  it('should render the fragment block', async () => {
+  xit('should render the fragment block', async () => {
     await page.waitForSelector('.fragment');
     const fragment = await page.$('.fragment');
     expect(fragment).toExist();

--- a/blocks/link-list/link-list.test.js
+++ b/blocks/link-list/link-list.test.js
@@ -31,11 +31,11 @@ describe('Link-List Block', () => {
       if (linkListItemWithjobLink) {
         const linkListItemWithJobLinkChildren = await linkListItemWithjobLink.$$('span');
 
-        linkListItemWithJobLinkChildren.forEach(async (child) => {
+        for (const child of linkListItemWithJobLinkChildren) {
           const classes = await child.evaluate((el) => el.classList);
           const hasJobClass = classes[0].startsWith('link-list-item__job');
           expect(hasJobClass).toBe(true);
-        });
+        }
       } else {
         console.log('No link-list-items with job links found.');
       };

--- a/blocks/small-screen-cta/small-screen-cta.test.js
+++ b/blocks/small-screen-cta/small-screen-cta.test.js
@@ -2,11 +2,11 @@ describe('Small Screen CTA Block', () => {
   beforeAll(async () => {
     await page.setViewport({ width: 350, height: 1000 });
     await page.goto(`${global.BASE_URL}pattern-library/`);
-    await page.$('.call-to-action');
+    await page.waitForSelector('.call-to-action');
   });
 
   it('On small screens should render the cta block', async () => {
-    const cta = page.$('.call-to-action');
+    const cta = await page.waitForSelector('.call-to-action');
     expect(cta).toExist();
   });
 

--- a/blocks/small-screen-cta/small-screen-cta.test.js
+++ b/blocks/small-screen-cta/small-screen-cta.test.js
@@ -13,13 +13,17 @@ describe('Small Screen CTA Block', () => {
   describe("On large screens", () => {
     beforeAll(async () => {
       await page.setViewport({ width: 1500, height: 1000 });
-      await page.goto(`${global.BASE_URL}`);
-      await page.$('#main-content');
     });
 
-    xit("should not render the cta block", async () => {
+    it("should not render the cta block", async () => {
+      // Wait for element to not be found in the DOM or to be hidden.
+      // Note; this will still return the ElementHandle of the hidden element.
       const cta = await page.waitForSelector('.call-to-action', { hidden: true, timeout: 3000 });
-      expect(cta).toBeNull();
+      const isDisplayNone = await page.evaluate(el => {
+        const computedStyle = window.getComputedStyle(el);
+        return computedStyle.getPropertyValue('display') === 'none';
+      }, cta);
+      expect(isDisplayNone).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary of changes

fix: prevent some async tests from sometimes failing
    
Adjusts tests to help resolve some intermittent failures due to some async race conditions. One check just needed an await and another needed to not be used in a foreach loop.
    
fix: re-enable one skipped small screen CTA test after fix
    
No longer skip one of the small screen CTA tests, after finding the issue with it. It was expecting null when the waitForSelector with the hidden: true option was actually returning the element.

fix: disable fragment test as class does not exist after decorate
    
Disabled the fragment test as it's checking for a block class that does not exist after the page has finished building. Was resulting in a flakey test that sometimes failed and sometimes passed based on when it ran.

**To discuss:** whether we need to await all decoration and scripts being finished for **all** tests, given what was discovered with the fragment test.

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-random-test-fails--adobe-design-website--adobe.aem.page/

## Checklist
<!-- Delete anything irrelevant to this PR -->
* [ ] This PR has visual changes, and has been reviewed by a designer.
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR has new code, so new tests were added or updated, and they pass.
* [ ] This PR affects production code, so it was browser tested (see below).
* [ ] This PR has copy changes, so copy was proofread and approved.
* [ ] The content of this PR requires documentation, so we added a detailed description of the component's purpose, requirements, quirks, and instructions for use by designers and developers. This includes accessibility information if pertinent.

## Validation
1. Make sure all PR checks have passed.
2. Review ran tests on PR.
3. Linked list test should pass. Small screen CTA test should pass. Fragment test should pass. Small screen CTA test for large screen hidden should run and pass.
4. Pull down branch and run tests a few times locally.

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [ ] Chrome
* [ ] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
