### PR TITLE
fix: typography review

### DIFF
--- a/blocks/article-header/article-header.css
+++ b/blocks/article-header/article-header.css
@@ -36,20 +36,24 @@
       }
     }
 
-    & :is(h3, h4, h5, h6):not(.author-meta__name) {
-      font-size: var(--spectrum-heading-size-s);
+    & :is(h3):not(.author-meta__name) {
+      font-size: var(--spectrum-title-size-xl);
+      font-weight: var(--spectrum-title-weight-xl);
+    }
 
-      @media (min-width: 22.5rem) {
-        font-size: var(--spectrum-body-size-l);
-      }
+    & :is(h4):not(.author-meta__name) {
+      font-size: var(--spectrum-title-size-l);
+      font-weight: var(--spectrum-title-weight-l);
+    }
 
-      @media (min-width: 48rem) {
-        font-size: var(--spectrum-body-size-xl);
-      }
+    & :is(h5):not(.author-meta__name) {
+      font-size: var(--spectrum-title-size-m);
+      font-weight: var(--spectrum-title-weight-m);
+    }
 
-      @media (min-width: 80rem) {
-        font-size: var(--spectrum-title-size-xl);
-      }
+    & :is(h6):not(.author-meta__name) {
+      font-size: var(--spectrum-title-size-s);
+      font-weight: var(--spectrum-title-weight-s);
     }
 
     & p:not(.author-description p) {

--- a/blocks/page-header/page-header.css
+++ b/blocks/page-header/page-header.css
@@ -104,10 +104,6 @@
   }
 
   @media (min-width: 48rem) {
-    h1 {
-      font-size: var(--spectrum-heading-size-l);
-    }
-
     .page-header__description--with-byline {
       font-size: var(--spectrum-title-size-l);
     }

--- a/blocks/page-header/page-header.css
+++ b/blocks/page-header/page-header.css
@@ -91,7 +91,7 @@
 .page-header {
   @media (min-width: 22.5rem) {
     h1 {
-      font-size: var(--spectrum-heading-size-xxl);
+      font-size: var(--spectrum-heading-size-xl);
     }
 
     .page-header__description {
@@ -105,21 +105,21 @@
 
   @media (min-width: 48rem) {
     h1 {
-      font-size: var(--spectrum-heading-size-xxl);
-    }
-
-    .page-header__description {
-      font-size: var(--spectrum-body-size-xl);
+      font-size: var(--spectrum-heading-size-l);
     }
 
     .page-header__description--with-byline {
-      font-size: var(--spectrum-title-size-xl);
+      font-size: var(--spectrum-title-size-l);
     }
   }
 
   @media (min-width: 80rem) {
     h1 {
       font-size: var(--spectrum-heading-size-xl);
+    }
+
+    .page-header__description {
+      font-size: var(--spectrum-body-size-xl);
     }
 
     .page-header__description--with-byline {

--- a/blocks/page-header/page-header.js
+++ b/blocks/page-header/page-header.js
@@ -20,7 +20,7 @@ export default async function decorate(block) {
 
   // there should always be a title, so create it as an h1
   const pageTitle = document.createElement("h1");
-  pageTitle.classList.add("page-header__title", "util-heading-xl");
+  pageTitle.classList.add("page-header__title", "util-heading-l");
   pageTitle.innerText = pageHeaderData.title;
   pageHeaderContent.append(pageTitle);
 

--- a/scripts/helpers/buildArticlePage.js
+++ b/scripts/helpers/buildArticlePage.js
@@ -23,7 +23,7 @@ const buildArticleTags = () => {
   tagsWrapper.classList.add("tags-aside");
 
   const heading = document.createElement("h2");
-  heading.classList.add("util-body-s");
+  heading.classList.add("util-title-s");
   heading.textContent = "Tags:";
   tagsWrapper.append(heading);
 

--- a/styles/base.css
+++ b/styles/base.css
@@ -459,35 +459,40 @@
   --spectrum-heading-size-xxl: var(--spectrum-font-size-1200);
   --spectrum-heading-weight-xxl: var(--spectrum-black-font-weight);
 
-  --spectrum-heading-size-xl: var(--spectrum-font-size-1000);
+  --spectrum-heading-size-xl: var(--spectrum-font-size-1100);
   --spectrum-heading-weight-xl: var(--spectrum-black-font-weight);
 
-  --spectrum-heading-size-l: var(--spectrum-font-size-800);
+  --spectrum-heading-size-l: var(--spectrum-font-size-900);
   --spectrum-heading-weight-l: var(--spectrum-black-font-weight);
 
-  --spectrum-heading-size-m: var(--spectrum-font-size-750);
+  --spectrum-heading-size-m: var(--spectrum-font-size-800);
   --spectrum-heading-weight-m: var(--spectrum-extra-bold-font-weight);
 
   --spectrum-heading-size-s: var(--spectrum-font-size-700);
   --spectrum-heading-weight-s: var(--spectrum-extra-bold-font-weight);
 
-  @media (min-width: 48rem) {
-    --spectrum-heading-size-l: var(--spectrum-font-size-1300);
+  @media (min-width: 22.5rem) {
+    --spectrum-heading-size-xxl: var(--spectrum-font-size-1300);
+    --spectrum-heading-size-xl: var(--spectrum-font-size-1200);
+    --spectrum-heading-size-l: var(--spectrum-font-size-1000);
     --spectrum-heading-size-m: var(--spectrum-font-size-900);
     --spectrum-heading-size-s: var(--spectrum-font-size-800);
   }
 
-  @media (min-width: 80rem) {
-    --spectrum-heading-size-xl: var(--spectrum-font-size-1200);
+  @media (min-width: 48rem) {
+    --spectrum-heading-size-xxl: var(--spectrum-font-size-1400);
+    --spectrum-heading-size-xl: var(--spectrum-font-size-1300);
     --spectrum-heading-size-l: var(--spectrum-font-size-1100);
     --spectrum-heading-size-m: var(--spectrum-font-size-1000);
+    --spectrum-heading-size-s: var(--spectrum-font-size-900);
   }
 
-  @media (min-width: 105rem) {
+  @media (min-width: 80rem) {
     --spectrum-heading-size-xxl: var(--spectrum-font-size-1500);
     --spectrum-heading-size-xl: var(--spectrum-font-size-1400);
     --spectrum-heading-size-l: var(--spectrum-font-size-1200);
     --spectrum-heading-size-m: var(--spectrum-font-size-1100);
+    --spectrum-heading-size-s: var(--spectrum-font-size-1000);
   }
 
   /* title */
@@ -515,7 +520,7 @@
   --spectrum-title-size-xs: var(--spectrum-font-size-100);
   --spectrum-title-weight-xs: var(--spectrum-bold-font-weight);
 
-  @media (min-width: 80rem) {
+  @media (min-width: 48rem) {
     --spectrum-title-size-xxxl: var(--spectrum-font-size-800);
     --spectrum-title-size-xxl: var(--spectrum-font-size-700);
     --spectrum-title-size-xl: var(--spectrum-font-size-600);
@@ -534,14 +539,13 @@
   --spectrum-detail-size-m: var(--spectrum-font-size-200);
   --spectrum-detail-size-s: var(--spectrum-font-size-100);
 
-  @media (min-width: 48rem) {
+  @media (min-width: 22.5rem) {
     --spectrum-detail-size-l: var(--spectrum-font-size-400);
   }
 
-  @media (min-width: 80rem) {
+  @media (min-width: 48rem) {
     --spectrum-detail-size-l: var(--spectrum-font-size-500);
     --spectrum-detail-size-m: var(--spectrum-font-size-300);
-    --spectrum-detail-size-s: var(--spectrum-font-size-100);
   }
 
   /* body */
@@ -555,16 +559,12 @@
   --spectrum-body-size-s: var(--spectrum-font-size-200);
   --spectrum-body-size-xs: var(--spectrum-font-size-100);
 
-  @media (min-width: 80rem) {
+  @media (min-width: 48rem) {
     --spectrum-body-size-xl: var(--spectrum-font-size-600);
     --spectrum-body-size-l: var(--spectrum-font-size-500);
     --spectrum-body-size-m: var(--spectrum-font-size-400);
     --spectrum-body-size-s: var(--spectrum-font-size-300);
     --spectrum-body-size-xs: var(--spectrum-font-size-200);
-  }
-
-  @media (min-width: 105rem) {
-    --spectrum-body-size-xl: var(--spectrum-font-size-600);
   }
 
   /* functional */

--- a/styles/global-blocks.css
+++ b/styles/global-blocks.css
@@ -763,7 +763,7 @@ a.card:hover {
   padding: 1.25rem 1rem;
   color: var(--color-text);
 
-  @container card-container (min-width: 24rem) {
+  @container card-container (min-width: 22.5rem) {
     min-height: 9rem;
   }
 
@@ -782,8 +782,20 @@ a.card:hover {
 .card__title {
   margin-block-end: 0.25rem;
 
-  @container card-container (min-width: 24rem) {
+  @container card-container (min-width: 22.5rem) {
     font-size: var(--spectrum-font-size-300);
+  }
+
+  @media (min-width: 48rem) {
+    @container card-container (min-width: 22.5rem) {
+      font-size: var(--spectrum-font-size-400);
+    }
+  }
+
+  @media (min-width: 80rem) {
+    @container card-container (min-width: 22.5rem) {
+      font-size: var(--spectrum-font-size-500);
+    }
   }
 
   @container card-container (min-width: 36rem) {
@@ -802,12 +814,30 @@ a.card:hover {
 }
 
 .card__description {
-  @container card-container (min-width: 24rem) {
+  @container card-container (min-width: 22.5rem) {
     font-size: var(--spectrum-font-size-200);
+  }
+
+  @media (min-width: 48rem) {
+    @container card-container (min-width: 22.5rem) {
+      font-size: var(--spectrum-font-size-300);
+    }
+  }
+
+  @media (min-width: 80rem) {
+    @container card-container (min-width: 22.5rem) {
+      font-size: var(--spectrum-font-size-400);
+    }
   }
 
   @container card-container (min-width: 36rem) {
     font-size: var(--spectrum-font-size-300);
+  }
+
+  @media (min-width: 80rem) {
+    @container card-container (min-width: 36rem) {
+      font-size: var(--spectrum-font-size-400);
+    }
   }
 
   @container card-container (min-width: 42rem) {

--- a/styles/global-blocks.css
+++ b/styles/global-blocks.css
@@ -957,7 +957,7 @@ a.card:hover {
 
 .tags-list {
   list-style-type: none;
-  margin: 0.25rem 0;
+  margin-block-start: 0.5rem;
   padding: 0;
   display: flex;
   flex-wrap: wrap;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -431,12 +431,12 @@ h6 {
 }
 
 h1,
-h2,
-h3 {
+h2 {
   font-family: var(--heading-font-family);
   line-height: var(--heading-line-height);
 }
 
+h3,
 h4,
 h5,
 h6 {
@@ -445,8 +445,8 @@ h6 {
 }
 
 h1 {
-  font-size: var(--spectrum-heading-size-xl);
-  font-weight: var(--spectrum-heading-weight-xl);
+  font-size: var(--spectrum-heading-size-xxl);
+  font-weight: var(--spectrum-heading-weight-xxl);
 }
 
 h2 {
@@ -455,23 +455,23 @@ h2 {
 }
 
 h3 {
-  font-size: var(--spectrum-heading-size-s);
-  font-weight: var(--spectrum-heading-weight-s);
+  font-size: var(--spectrum-title-size-xxxl);
+  font-weight: var(--spectrum-title-weight-xxxl);
 }
 
 h4 {
+  font-size: var(--spectrum-title-size-xxl);
+  font-weight: var(--spectrum-title-weight-xxl);
+}
+
+h5 {
   font-size: var(--spectrum-title-size-xl);
   font-weight: var(--spectrum-title-weight-xl);
 }
 
-h5 {
-  font-size: var(--spectrum-title-size-m);
-  font-weight: var(--spectrum-title-weight-m);
-}
-
 h6 {
-  font-size: var(--spectrum-title-size-s);
-  font-weight: var(--spectrum-title-weight-s);
+  font-size: var(--spectrum-title-size-l);
+  font-weight: var(--spectrum-title-weight-l);
 }
 
 input,


### PR DESCRIPTION
## Summary of changes
- Modify styling for h3 through h6 in articles
- Add what seemed to be gaps in `--spectrum-heading-size-*` tokens on screen size increase
  - Ex: On a large screen, `--spectrum-heading-size-l` was larger than both `--spectrum-heading-size-xl` and `--spectrum-heading-size-xxl`
- Reflect design with typography breakpoints
  - The Figma sheets represent a `max-width` approach, so fonts grow earlier than before
- Style tags heading on article pages
- Update Page Header styles to reflect changes in tokens
- Update Card styles such that the content font-size of Cards in a four-up layout grow with the screen

## Relevant Links
- Designs: [Figma](https://www.figma.com/design/QzvOszpLGT7fwSd6N7gaDW/Adobe-Design?node-id=1135-14473&t=nVliYDqHoSywXieG-1)
- Story: [ADB-249](https://sparkbox.atlassian.net/browse/ADB-249)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-typography-review--adobe-design-website--adobe.aem.page/

## Validation
1. Navigate to the [Pattern Library typography page](pattern-library/typography)
2. Review font styles across all breakpoints
3. Navigate to the [article typography page](ideas/article-typography)
4. Review font styles across all breakpoints
5. Navigate to the [example article](ideas/example-article)
6. Scroll to the author bio and review the new font style for the "Tags" section
7. Navigate to the [homepage]()
8. Scroll to the "Behind the Design" section
9. Review the Card content on all breakpoints
