### PR TITLE
fix: article header image max-width at large screens

### DIFF
--- a/styles/global-blocks.css
+++ b/styles/global-blocks.css
@@ -463,7 +463,7 @@
 
     & .image-with-caption__image img {
       width: calc(100vw - 4rem);
-      max-width: 120rem;
+      max-width: 102rem;
       margin-inline-start: 50%;
       transform: translateX(-50%);
       border-radius: var(--spectrum-corner-radius-800);


### PR DESCRIPTION
## Summary of changes

The article header image was too big at large screens (1920 breakpoint and larger).

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-article-image-size--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR has new code, so new tests were added or updated, and they pass.
* [ ] This PR affects production code, so it was browser tested (see below).

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. View an article page and inspect the article header image. Confirm max-width at large breakpoint 1920 and larger matches designed max-width of 1632px.

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [x] Chrome
* [ ] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
