### PR TITLE
fix: missing font styles on 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="/styles/base.css">
   <link rel="stylesheet" href="/styles/styles.css">
   <link rel="stylesheet" href="/styles/global-blocks.css">
+  <link rel="stylesheet" href="https://use.typekit.net/ezf4sbn.css">
   <script src="/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
   <script type="module">
     const getRandom404Data = async () => {


### PR DESCRIPTION
## Summary of changes
- Missing font styles on 404 page

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/careers/asdfadsf
- After: https://fix-404-font--adobe-design-website--adobe.aem.page/careers/asdfasdf
