### PR TITLE
feat: button down state and style fixes

### DIFF
--- a/blocks/filter-group/filter-group.css
+++ b/blocks/filter-group/filter-group.css
@@ -79,6 +79,15 @@
     cursor: not-allowed;
     opacity: 1;
   }
+
+  &:active {
+    transform:
+      perspective(max(
+        var(--spectrum-downstate-height, 2.0rem),
+        var(--spectrum-downstate-width, 150px) * var(--spectrum-component-size-width-ratio-down)
+      ))
+      translateZ(var(--spectrum-component-size-difference-down));
+  }
 }
 
 .filter-group__button:last-child {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -213,9 +213,6 @@ a.nav__home-link {
 
 /* theme switcher */
 .theme-toggle {
-  --spectrum-component-size-minimum-perspective-down: 1.5rem;
-  --spectrum-component-size-difference-down: -2px;
-
   --spectrum-switch-label-color-default: var(--spectrum-gray-800);
   --spectrum-switch-label-color-hover: var(--spectrum-gray-900);
   --spectrum-switch-label-color-down: var(--spectrum-gray-900);

--- a/blocks/link-list/link-list.css
+++ b/blocks/link-list/link-list.css
@@ -126,7 +126,8 @@
   font-weight: var(--spectrum-medium-font-weight);
   width: auto;
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     color: var(--footer-link-color-text-hover);
     text-decoration: underline;
   }
@@ -149,7 +150,8 @@
     font-size: var(--spectrum-font-size-300);
     font-weight: var(--spectrum-bold-font-weight);
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
       border-color: var(--footer-link-color-border-hover);
       background-color: var(--footer-link-background-hover);
       color: var(--footer-link-color-text-hover);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -179,7 +179,24 @@ async function loadLazy(doc) {
   // loads the footer component, along with its stylesheet
   loadFooter(doc.querySelector('footer'));
   cleanEmptyDivs(main);
+
+  // Down state: include widths and heights for elements that use S2 calculated perspective.
+  setCalculatedPerspective();
+  const setCalcPerspectiveDebounced = debounce(() => { setCalculatedPerspective() });
+  window.addEventListener("resize", setCalcPerspectiveDebounced);
 }
+
+/**
+ * Down state: include widths and heights for elements that use S2 calculated perspective.
+ * Sets custom property values used by the perspective CSS.
+ */
+const setCalculatedPerspective = () => {
+  const elements = document.querySelectorAll('.button, .filter-group__button');
+  elements.forEach(el => {
+    el.style.setProperty('--spectrum-downstate-width', el.offsetWidth + 'px');
+    el.style.setProperty('--spectrum-downstate-height', el.offsetHeight + 'px');
+  });
+};
 
 /**
  * Loads everything that happens a lot later,

--- a/styles/base.css
+++ b/styles/base.css
@@ -80,6 +80,7 @@
   --spectrum-blue-300: rgb(203 226 254);
   --spectrum-blue-400: rgb(172 207 253);
   --spectrum-blue-500: rgb(142 185 252);
+  --spectrum-blue-700: rgb(93 137 255);
   --spectrum-blue-800: rgb(75 117 255);
   --spectrum-blue-900: rgb(59 99 251);
   --spectrum-blue-1000: rgb(39 77 234);
@@ -139,6 +140,7 @@
     --spectrum-blue-300: rgb(12 33 117);
     --spectrum-blue-400: rgb(26 58 195);
     --spectrum-blue-500: rgb(26 58 195);
+    --spectrum-blue-700: rgb(52 91 248);
     --spectrum-blue-800: rgb(64 105 253);
     --spectrum-blue-900: rgb(86 129 255);
     --spectrum-blue-1000: rgb(105 149 254);

--- a/styles/base.css
+++ b/styles/base.css
@@ -616,6 +616,10 @@
   --spectrum-animation-ease-out: cubic-bezier(0, 0, 0.4, 1);
   --spectrum-animation-ease-linear: cubic-bezier(0, 0, 1, 1);
 
+  --spectrum-component-size-width-ratio-down: 0.3333;
+  --spectrum-component-size-minimum-perspective-down: 1.5rem;
+  --spectrum-component-size-difference-down: -2px;
+
   /* ** PAGE LEVEL ** */
   --page-background: var(--color-background);
   --page-background-nav: var(--spectrum-gray-25);

--- a/styles/delayed-styles.css
+++ b/styles/delayed-styles.css
@@ -6,6 +6,7 @@
     --spectrum-blue-300: rgb(12 33 117);
     --spectrum-blue-400: rgb(26 58 195);
     --spectrum-blue-500: rgb(26 58 195);
+    --spectrum-blue-700: rgb(52 91 248);
     --spectrum-blue-800: rgb(64 105 253);
     --spectrum-blue-900: rgb(86 129 255);
     --spectrum-blue-1000: rgb(105 149 254);
@@ -66,6 +67,7 @@
     --spectrum-blue-300: rgb(203 226 254);
     --spectrum-blue-400: rgb(172 207 253);
     --spectrum-blue-500: rgb(142 185 252);
+    --spectrum-blue-700: rgb(93 137 255);
     --spectrum-blue-800: rgb(75 117 255);
     --spectrum-blue-900: rgb(59 99 251);
     --spectrum-blue-1000: rgb(39 77 234);

--- a/styles/global-blocks.css
+++ b/styles/global-blocks.css
@@ -567,6 +567,10 @@
       background: var(--icon-cancel-sm) center no-repeat;
     }
 
+    &:hover {
+      border-color: var(--spectrum-gray-400);
+    }
+
     &:active,
     &:focus,
     &:focus-visible {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -167,7 +167,8 @@ main picture:not([class]) > img:not([class]) {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     background-color: var(--color-button-background-primary-hover);
     color: var(--color-button-text-primary);
   }
@@ -208,7 +209,8 @@ main picture:not([class]) > img:not([class]) {
   border: 2px solid var(--color-button-border-primary-outline);
   color: var(--color-button-text-primary-outline);
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     border-color: var(--color-button-border-primary-outline-hover);
     background-color: var(--color-button-background-primary-outline-hover);
     color: var(--color-button-text-primary-outline-hover);
@@ -254,7 +256,8 @@ main picture:not([class]) > img:not([class]) {
   border: 2px solid var(--color-button-border-static-black);
   color: var(--color-button-text-static-black);
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     border-color: var(--color-button-border-static-black-hover);
     background-color: var(--color-button-background-static-black-hover);
     color: var(--color-button-text-static-black-hover);
@@ -293,7 +296,8 @@ main picture:not([class]) > img:not([class]) {
   border: 2px solid var(--color-button-border-static-white);
   color: var(--color-button-text-static-white);
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     border-color: var(--color-button-border-static-white-hover);
     background-color: var(--color-button-background-static-white-hover);
     color: var(--color-button-text-static-white-hover);
@@ -323,7 +327,8 @@ main picture:not([class]) > img:not([class]) {
   background-color: var(--color-button-background-accent);
   color: var(--color-button-text-accent);
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     background-color: var(--color-button-background-accent-hover);
     color: var(--color-button-text-accent);
   }
@@ -347,7 +352,8 @@ main picture:not([class]) > img:not([class]) {
   font-size: var(--spectrum-font-size-200);
   font-weight: var(--spectrum-medium-font-weight);
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     color: var(--color-button-text-ghost-hover);
     text-decoration: underline;
   }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -341,7 +341,7 @@ main picture:not([class]) > img:not([class]) {
 
 :root:has(#color-scheme:checked) .button--accent {
   --color-button-background-accent: var(--spectrum-blue-800);
-  --color-button-background-accent-hover: var(--spectrum-blue-900);
+  --color-button-background-accent-hover: var(--spectrum-blue-700);
 }
 
 .button--ghost {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -133,6 +133,15 @@ main picture:not([class]) > img:not([class]) {
     cursor: unset;
   }
 
+  &:active {
+    transform:
+      perspective(max(
+        var(--spectrum-downstate-height, 2.0rem),
+        var(--spectrum-downstate-width, 150px) * var(--spectrum-component-size-width-ratio-down)
+      ))
+      translateZ(var(--spectrum-component-size-difference-down));
+  }
+
   @media (min-width: 22.5rem) {
     width: fit-content;
     white-space: nowrap;


### PR DESCRIPTION
## Summary of changes

A few bug fixes and style enhancements:

**feature: s2 button down state using calculated perspective**
Adds the Spectrum 2 down state for buttons, using the "calculated perspective" as documented in the Down State section of the S2 documentation. This includes setting the width and height of the button to custom property values. This helps the effect to not be too pronounced as the button gets wider.

**fix: adding missing `focus-visible` styles on buttons**

**fix: correct the accent button color on hover in dark mode to match spectrum 2 styles.** 
    This is now darker than the default color, which has more contrast.

**feature: add search field hover border color**

## Relevant Links
- Story: [ADB-264](https://sparkbox.atlassian.net/browse/ADB-264) [ADB-264](https://sparkbox.atlassian.net/browse/ADB-265)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://feat-button-down-state--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has visual changes, and has been reviewed by a designer.
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR has new code, so new tests were added or updated, and they pass.
* [ ] This PR affects production code, so it was browser tested (see below).
* [ ] This PR has copy changes, so copy was proofread and approved.
* [ ] The content of this PR requires documentation, so we added a detailed description of the component's purpose, requirements, quirks, and instructions for use by designers and developers. This includes accessibility information if pertinent.

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. Visit testing link.
4. Confirm button down state on various buttons. Confirm that custom properties with width and height are being set, including on browser resize.
5. Buttons should now should have focus-visible styles similar to hover styles. Test with keyboard focus of buttons.
6. Hover and focus-visible of the accent button in dark mode should have a darker background color than default, not lighter. Test on home page "view design careers" button.
7. Search input should show slight change in border color on hover. Test in mobile menu, dark and light mode.


---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [x] Chrome
* [ ] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
