### PR TITLE
chore: adjust language of subpages to be consistent

### DIFF
--- a/404.html
+++ b/404.html
@@ -49,14 +49,14 @@
       const randomImagePicture = randomImageContainer.querySelector("img");
       const randomImageCaption = randomImageContainer.querySelector("figcaption");
       const buttons = document.querySelectorAll(".not-found .button");
-  
+
       if (window.location.pathname.includes("/careers/")) {
         heading.classList.add("not-found__heading--careers");
         heading.textContent = "The job listing you are looking for cannot be found or is no longer active.";
         description.remove();
         randomImageContainer.remove();
         buttons[0].setAttribute("href", "/careers/");
-        buttons[0].innerText = "See current job openings";
+        buttons[0].innerText = "See current job listings";
         buttons[1].setAttribute("href", "/");
         buttons[1].innerText = "Go back home";
       } else {
@@ -191,7 +191,7 @@
       </figure>
       <div class="button-group">
         <a href="/" class="button button--accent">Go back home</a>
-        <a href="/careers/" class="button button--primary-outline">See current job openings</a>
+        <a href="/careers/" class="button button--primary-outline">See current job listings</a>
       </div>
     </section>
   </main>

--- a/blocks/filter-group/filter-group-functions.js
+++ b/blocks/filter-group/filter-group-functions.js
@@ -4,7 +4,7 @@
 import { fetchAndBuildIdeas, debounce } from "../../scripts/helpers/index.js";
 import { updateFilter, getCurrentFiltersArray } from "./filter-group-utils.js";
 import {
-  initialMaxIdeas,
+  initialMaxArticles,
   calculateGroupTotal,
   rearrangeFeatures,
   updateLoadButtonState,
@@ -40,7 +40,7 @@ const refreshArticleContent = async (selectedFilters = []) => {
   const groupTotal = calculateGroupTotal(layoutType === "two-up");
   const fragment = await fetchAndBuildIdeas({
     tagName: selectedFilters,
-    maxArticles: initialMaxIdeas(features?.length ?? 0, groupTotal),
+    maxArticles: initialMaxArticles(features?.length ?? 0, groupTotal),
     gridItemClass: layoutType === "two-up" ? "grid-item--50" : "grid-item--25",
     hasHorizontalScroll: false,
   });

--- a/blocks/ideas/ideas-functions.js
+++ b/blocks/ideas/ideas-functions.js
@@ -94,7 +94,7 @@ export const buildIdeasFeature = (featureContent) => {
  * @param {number} groupTotal How many cards before or after a feature.
  * @returns {number}
  */
-export const initialMaxIdeas = (totalFeatures, groupTotal) => {
+export const initialMaxArticles = (totalFeatures, groupTotal) => {
   const minTotalWithFeatures = (totalFeatures + 1) * groupTotal;
   // Include a larger minimum of 3x the grouping, so the total is never too small.
   return Math.max(minTotalWithFeatures, groupTotal * 3);

--- a/blocks/ideas/ideas.js
+++ b/blocks/ideas/ideas.js
@@ -2,7 +2,7 @@ import { fetchAndBuildIdeas } from "../../scripts/helpers/index.js";
 import {
   buildIdeasFeature,
   calculateGroupTotal,
-  initialMaxIdeas,
+  initialMaxArticles,
   handleLoadMore,
   rearrangeFeatures,
 } from "./ideas-functions.js";
@@ -74,7 +74,7 @@ export default function decorate(block) {
   const fetchAndAppend = async () => {
     const fragment = await fetchAndBuildIdeas({
       tagName: settings.tags.split(","),
-      maxArticles: initialMaxIdeas(features.length, groupTotal),
+      maxArticles: initialMaxArticles(features.length, groupTotal),
       gridItemClass:
         settings.layoutType === "two-up" ? "grid-item--50" : "grid-item--25",
       hasHorizontalScroll: false,

--- a/scripts/helpers/buildJobListingPage.js
+++ b/scripts/helpers/buildJobListingPage.js
@@ -12,7 +12,7 @@ import {
  * @return {void}
  */
 
-export const buildCareersListingPage = async () => {
+export const buildJobListingPage = async () => {
   if (window.errorCode === "404") return;
 
   const listingMetadata = getListingMetadata();

--- a/scripts/helpers/index.js
+++ b/scripts/helpers/index.js
@@ -21,7 +21,7 @@ export { createFocusTrap } from "./createFocusTrap.js";
 // Full-page logic
 export { appendLiveRegion } from "./appendLiveRegion.js";
 export { decorateThemeBackgroundVisuals } from "./themeBackgrounds.js";
-export { buildCareersListingPage } from "./buildCareersListingPage.js";
+export { buildJobListingPage } from "./buildJobListingPage.js";
 export { buildArticlePage } from "./buildArticlePage.js";
 export { buildSiteContentPage } from "./buildSiteContentPage.js";
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -20,7 +20,7 @@ import {
   debounce,
   isSubPageOf,
   buildArticlePage,
-  buildCareersListingPage,
+  buildJobListingPage,
   buildSiteContentPage,
   appendLiveRegion,
 } from './helpers/index.js';
@@ -167,7 +167,7 @@ async function loadLazy(doc) {
   };
 
   // decorate careers listing page
-  if (isSubPageOf('careers')) buildCareersListingPage();
+  if (isSubPageOf('careers')) buildJobListingPage();
 
   // decorate site content page
   if (window.location.pathname === "/pattern-library/site-content") buildSiteContentPage();


### PR DESCRIPTION
## Summary of changes
- Adjust language for consistency: use "job listing" and "article" where possible. 

## Relevant Links
- Designs: [Figma](FIGMA_URL)
- Story: [ADB-271](https://sparkbox.atlassian.net/browse/ADB-271)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://glossary-updates--adobe-design-website--adobe.aem.page/

## Validation
1. Check that Ideas and Careers render 
1. Check that a job post, like `/careers/r154528-sr-content-strategy-manager` renders
1. High five!
