### PR TITLE
fix: address design review feedback

### DIFF
--- a/404.html
+++ b/404.html
@@ -108,21 +108,6 @@
       }
     }
 
-    .not-found__description,
-    .not-found__image {
-      @media (min-width: 48rem) {
-        max-width: 25.5rem;
-      }
-
-      @media (min-width: 80rem) {
-        max-width: 33rem;
-      }
-
-      @media (min-width: 105rem) {
-        max-width: 34.5rem;
-      }
-    }
-
     .not-found__description {
       font-family: var(--spectrum-sans-serif-font);
       font-weight: var(--spectrum-bold-font-weight);
@@ -130,6 +115,7 @@
       line-height: 1.3;
       margin-block-start: 0;
       margin-block-end: 1rem;
+      max-width: 40ch;
 
       @media (min-width: 48rem) {
         font-size: var(--spectrum-font-size-500);
@@ -161,8 +147,13 @@
       }
     }
 
+    .not-found__image img {
+      max-height: 40vh;
+    }
+
     .not-found__image figcaption {
-      margin-block-start: 0.25rem;
+      margin-block-start: 0.5rem;
+      max-width: 60ch;
 
       @media (min-width: 48rem) {
         margin-block-start: 0.5rem;
@@ -170,6 +161,7 @@
 
       @media (min-width: 80rem) {
         margin-block-start: 1rem;
+        font-size: var(--spectrum-font-size-200);
       }
     }
   </style>

--- a/blocks/article-header/article-header.css
+++ b/blocks/article-header/article-header.css
@@ -60,8 +60,8 @@
       margin-block-start: 0.5rem;
     }
 
-    & ul > li:not(:last-child),
-    & ol > li:not(:last-child) {
+    & ul > li:not(:last-of-type),
+    & ol > li:not(:last-of-type) {
       margin-block-end: 1rem;
     }
   }
@@ -73,14 +73,14 @@
   max-width: 66rem;
   margin-inline: auto;
   margin-block-end: var(--spacing-global-block-end-small-screen);
-  gap: 2rem;
+  row-gap: 2rem;
 
   @media (min-width: 22.5rem) {
     margin-block-end: var(--spacing-global-block-end-medium-screen);
   }
 
   @media (min-width: 48rem) {
-    gap: 4rem;
+    row-gap: 4rem;
     margin-block-end: var(--spacing-global-block-end-large-screen);
   }
 
@@ -101,19 +101,19 @@
 }
 
 .article-header__headline-group {
-  gap: 0.5rem;
+  row-gap: 0.5rem;
 
   @media (min-width: 48rem) {
-    gap: 0.75rem;
+    row-gap: 0.75rem;
   }
 
   @media (min-width: 80rem) {
-    gap: 1rem;
+    row-gap: 1rem;
   }
 }
 
 .article-header__byline-group {
-  gap: 0.5rem;
+  row-gap: 0.5rem;
 }
 
 .article-header__eyebrow {

--- a/blocks/article-header/article-header.css
+++ b/blocks/article-header/article-header.css
@@ -59,6 +59,11 @@
     & p:not(.author-description p) {
       margin-block-start: 0.5rem;
     }
+
+    & ul > li:not(:last-child),
+    & ol > li:not(:last-child) {
+      margin-block-end: 1rem;
+    }
   }
 }
 
@@ -68,14 +73,14 @@
   max-width: 66rem;
   margin-inline: auto;
   margin-block-end: var(--spacing-global-block-end-small-screen);
-  gap: 1rem;
+  gap: 2rem;
 
   @media (min-width: 22.5rem) {
     margin-block-end: var(--spacing-global-block-end-medium-screen);
   }
 
   @media (min-width: 48rem) {
-    gap: 1.25rem;
+    gap: 4rem;
     margin-block-end: var(--spacing-global-block-end-large-screen);
   }
 
@@ -87,6 +92,28 @@
   h1 {
     font-size: var(--spectrum-heading-size-m);
   }
+}
+
+.article-header__headline-group,
+.article-header__byline-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.article-header__headline-group {
+  gap: 0.5rem;
+
+  @media (min-width: 48rem) {
+    gap: 0.75rem;
+  }
+
+  @media (min-width: 80rem) {
+    gap: 1rem;
+  }
+}
+
+.article-header__byline-group {
+  gap: 0.5rem;
 }
 
 .article-header__eyebrow {

--- a/blocks/article-header/article-header.js
+++ b/blocks/article-header/article-header.js
@@ -28,45 +28,58 @@ export default async function decorate(block) {
   const main = document.querySelector("#main-content");
   main.classList.add("article-content");
 
+  // create the headline group container element
+  const headlineGroup = document.createElement("div");
+  headlineGroup.classList.add("article-header__headline-group")
+  articleHeader.append(headlineGroup);
+
   // there should always be a title, so create it as an h1
   const pageTitle = document.createElement("h1");
   pageTitle.classList.add("article-header__title", "util-heading-xl");
   pageTitle.innerText = articleHeaderData.title;
-  articleHeader.append(pageTitle);
+  headlineGroup.append(pageTitle);
 
   // if there is a subtitle, add it as an h2
   if (articleHeaderData.subtitle) {
     const pageSubtitle = document.createElement("p");
     pageSubtitle.classList.add("article-header__subtitle", "util-title-m");
     pageSubtitle.innerText = articleHeaderData.subtitle;
-    articleHeader.append(pageSubtitle);
+    headlineGroup.append(pageSubtitle);
   }
 
-  // if there is a publication date,
-  if (articleHeaderData.pubDate) {
-    // create a time element
-    const pubDate = document.createElement("time");
-    pubDate.classList.add("article-header__date", "util-body-xs");
-    pubDate.innerText = articleHeaderData.pubDate;
+  // if there is either a publication date or author,
+  if (articleHeaderData.pubDate || articleHeaderData.author) {
+    // create the byline group container element
+    const bylineGroup = document.createElement("div");
+    bylineGroup.classList.add("article-header__byline-group");
+    articleHeader.append(bylineGroup);
 
-    // find the UTC string of the date string provided
-    const pubDateRaw = Date.parse(articleHeaderData.pubDate);
-    const preppedDate = new Date(pubDateRaw).toUTCString();
+    // if there is a publication date,
+    if (articleHeaderData.pubDate) {
+      // create a time element
+      const pubDate = document.createElement("time");
+      pubDate.classList.add("article-header__date", "util-body-xs");
+      pubDate.innerText = articleHeaderData.pubDate;
 
-    // add that to our time element
-    pubDate.setAttribute('datetime', preppedDate);
+      // find the UTC string of the date string provided
+      const pubDateRaw = Date.parse(articleHeaderData.pubDate);
+      const preppedDate = new Date(pubDateRaw).toUTCString();
 
-    articleHeader.append(pubDate);
-  }
+      // add that to our time element
+      pubDate.setAttribute('datetime', preppedDate);
 
-  // if there is an author, build a byline
-  if (articleHeaderData.author) {
-    const byLine = document.createElement("div");
-    byLine.innerHTML = `
-      <div class="article-header__byline util-body-xs">Words by</div>
-      <div class="article-header__author util-title-m">${articleHeaderData.author}</div>
-    `;
-    articleHeader.append(byLine);
+      bylineGroup.append(pubDate);
+    }
+
+    // if there is an author, build a byline
+    if (articleHeaderData.author) {
+      const byLine = document.createElement("div");
+      byLine.innerHTML = `
+        <div class="article-header__byline util-body-xs">Words by</div>
+        <div class="article-header__author util-title-m">${articleHeaderData.author}</div>
+      `;
+      bylineGroup.append(byLine);
+    }
   }
 
   // if there is an image, let's add an image

--- a/styles/global-blocks.css
+++ b/styles/global-blocks.css
@@ -144,7 +144,7 @@
     justify-content: space-between;
   }
 
-  @media (min-width: 80rem) {
+  @media (min-width: 67.5rem) {
     display: none;
   }
 
@@ -164,9 +164,9 @@
 }
 
 .listing-container {
-  @media (min-width: 80rem) {
+  @media (min-width: 67.5rem) {
     display: grid;
-    grid-template-columns: 8fr 1fr 3fr;
+    grid-template-columns: 70ch 1fr 3fr;
     grid-template-rows: auto 1fr;
     grid-template-areas:
       "title title title"
@@ -174,27 +174,24 @@
   }
 
   > h1 {
-    margin-block-start: 2rem;
     margin-block-end: 1rem;
 
     @media (min-width: 36rem) {
-      margin-block-start: 4rem;
       margin-block-end: 2.5rem;
     }
 
-    @media (min-width: 80rem) {
-      margin-block-start: 12rem;
-      margin-block-end: 10rem;
+    @media (min-width: 67.5rem) {
+      margin-block-end: var(--spacing-global-block-end-medium-screen);
       grid-area: title;
     }
 
     @media (min-width: 105rem) {
-      margin-block-end: 18rem;
+      margin-block-end: 8.75rem;
     }
   }
 
   > .listing-details {
-    @media (min-width: 80rem) {
+    @media (min-width: 67.5rem) {
       grid-area: details;
     }
   }
@@ -216,7 +213,7 @@
         margin-block-start: var(--spacing-heading-block-start-large-screen);
       }
 
-      @media (min-width: 80rem) {
+      @media (min-width: 67.5rem) {
         margin-block-start: var(--spacing-heading-block-start-xl-screen);
       }
     }
@@ -225,7 +222,7 @@
       margin-block-start: 0;
     }
 
-    @media (min-width: 80rem) {
+    @media (min-width: 67.5rem) {
       grid-area: content;
     }
   }
@@ -244,7 +241,7 @@
     grid-template-areas: "location detail-grid button";
   }
 
-  @media (min-width: 80rem) {
+  @media (min-width: 67.5rem) {
     align-self: start;
     position: sticky;
     top: calc(5rem + var(--page-nav-height));
@@ -260,7 +257,7 @@
       width: auto;
     }
 
-    @media (min-width: 80rem) {
+    @media (min-width: 67.5rem) {
       margin-block-end: 3rem;
     }
   }
@@ -273,7 +270,7 @@
   gap: 1rem;
   align-self: start;
 
-  @media (min-width: 80rem) {
+  @media (min-width: 67.5rem) {
     display: flex;
     flex-direction: column;
   }
@@ -320,7 +317,7 @@
       font-size: var(--spectrum-font-size-400);
     }
 
-    @media (min-width: 80rem) {
+    @media (min-width: 67.5rem) {
       font-weight: var(--spectrum-extra-bold-font-weight);
       font-size: var(--spectrum-font-size-600);
     }
@@ -331,7 +328,7 @@
       font-size: var(--spectrum-font-size-200);
     }
 
-    @media (min-width: 80rem) {
+    @media (min-width: 67.5rem) {
       font-weight: var(--spectrum-medium-font-weight);
       font-size: var(--spectrum-font-size-300);
     }
@@ -355,14 +352,16 @@
 }
 
 .listing-prefooter {
-  margin-block-end: 4rem;
+  margin-block-end: var(--spacing-global-block-end-small-screen);
+  max-width: 80ch;
+  font-size: var(--spectrum-font-size-200);
 
   @media (min-width: 80rem) {
-    margin-block-end: 5rem;
+    margin-block-end: var(--spacing-global-block-end-medium-screen);
   }
 
   @media (min-width: 105rem) {
-    margin-block-end: 6.5rem;
+    margin-block-end: var(--spacing-global-block-end-large-screen);
   }
 }
 

--- a/styles/global-blocks.css
+++ b/styles/global-blocks.css
@@ -472,7 +472,7 @@
 
     & .image-with-caption__image img {
       width: calc(100vw - 4rem);
-      max-width: 102rem;
+      max-width: 66rem;
       margin-inline-start: 50%;
       transform: translateX(-50%);
       border-radius: var(--spectrum-corner-radius-800);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -535,6 +535,10 @@ main > .section.small-screen-cta-container > .grid-container {
   @media (min-width: 22.5rem) {
     margin-block-end: 2.5rem;
   }
+
+  @media (min-width: 80rem) {
+    margin-block-end: var(--spacing-global-block-end-large-screen);
+  }
 }
 
 .grid-container {


### PR DESCRIPTION
## Summary of changes
Shawn's site-wide feedback has been addressed. See validation for exact changes.

## Relevant Links
- Story: [ADB-272](https://sparkbox.atlassian.net/browse/ADB-272)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-design-review-feedback--adobe-design-website--adobe.aem.page/

## Validation
1. Open the [main preview site](https://main--adobe-design-website--adobe.aem.page/) and the [branch preview site](https://fix-design-review-feedback--adobe-design-website--adobe.aem.page/), we're doing some compare and contrast today

### Homepage
1. Verify the page header now has a `margin-block-end` value after the small-screen-cta block disappears at large screens

### Job Listing
1. Navigate to `/careers/example-job-posting`
2. There is no longer additional `margin-block-start` on the `h1`, and there is less `margin-block-end` across all screen sizes
3. The page adopts the content and sidebar layout earlier now (at 67.5rem instead of 80rem). This was done to avoid the job details stretching across too wide on medium screens.
4. The job listing content now has a max-width of `70ch`
5. The listing prefooter is a smaller font-size than the job listing content, and has a max-width of `80ch`

### Article
1. Navigate to `/ideas/example-article`
2. Ordered and unordered lists have some `margin-block-end` applied between list items
3. The title and subtitle are now grouped into their own container, and are spaced closer together
4. The publication date and byline are now grouped into their own container, and are spaced closer together
5. The article header image and the full-width image have a smaller max-width (from `102rem` to `66rem`) to avoid the image taking up the entire screen on larger screens

### Careers
1. Navigate to `/careers/`
2. There is now a `margin-block-end` applied after any heading used in the responsive-split-layout block
3. There is now less `padding-inline` one each responsive-split-layout block

_Note: The Careers page work was moved to #166._

### Default 404
1. Navigate to any invalid endpoint that isn't under `/careers/`
2. The image has a max-height of `40vh` set so it doesn't get too large on medium screens
3. The page description and image caption now have a max-width set on them to better match the image height change

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [x] Firefox
* [x] Chrome
* [ ] Safari
* [ ] Edge

**Android**
* [x] Firefox
* [x] Chrome
* [ ] Edge

**iOS**
* [ ] Safari
