### PR TITLE
fix: search field keyboard focus out in safari

### DIFF
--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -268,7 +268,7 @@ function createSearchBox(block, config) {
   searchInput.addEventListener('focus', (e) => handleSearch(e?.target, block, config));
 
   /**
-   * Handle escape or clear button. Collapse, clear search value, and clear search results.
+   * Handle escape or clear button. Optional collapse, clear search value, and clear search results.
    * 
    * @param {boolean} collapseExpanded Whether to collapse the expanded large screen search.
    */
@@ -314,6 +314,7 @@ function createSearchBox(block, config) {
    */
   const collapseAndClear = () => {
     box.classList.remove('search__box--expanded');
+    toggleButton.toggleAttribute('aria-expanded', false);
     clearSearchResults(block);
     clearSearchURLParam();
   };
@@ -334,12 +335,13 @@ function createSearchBox(block, config) {
   });
 
   /**
-   * Make sure change in keyboard (tab) focus to another element outside of search also collapses and clears the search results.
+   * Make sure change in keyboard (tab) focus to another element outside of search also clears the search results.
    * Important for mobile menu focus moving from search to the nav.
    */
-  box.addEventListener('blur', function(e) {
+  box.addEventListener('focusout', function(e) {
       // Check if the element that gained focus (relatedTarget) is outside the search.
-      if (!box.contains(e.relatedTarget)) {
+      // Note: relatedTarget will be null in Safari when reaching expand/collapse button.
+      if (e.relatedTarget !== null && !box.contains(e.relatedTarget)) {
         collapseAndClear();
       }
   }, true);


### PR DESCRIPTION
## Summary of changes
Fix some issues in Safari with collapsing the search from the expand/collapse button and tabbing out of the field clear/collapse, due to Safari having `relatedTarget` equal to `null` on the blur/focusout of the button element which is next in the tab order.

Original issue:
- expand desktop search, type into search, click search icon to collapse, and it would close and open right back up again.

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-search-safari--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR has new code, so new tests were added or updated, and they pass.
* [ ] This PR affects production code, so it was browser tested (see below).

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. In Safari, confirm that "original issue" as described above is fixed.
4. Test in other browsers.
5. Test general search functionality and mobile search as well, to confirm no regressions.

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [x] Chrome
* [x] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
