### PR TITLE
fix: reduce heading font size at a few breakpoints

### DIFF
--- a/blocks/article-header/article-header.css
+++ b/blocks/article-header/article-header.css
@@ -23,7 +23,7 @@
     & :is(h1, h2, h3, h4, h5, h6):not(.author-meta__name) {
       margin-block-start: var(--spacing-heading-block-start-small-screen);
 
-      @media (min-width: 22.5rem) {
+      @media (min-width: 36rem) {
         margin-block-start: var(--spacing-heading-block-start-medium-screen);
       }
 
@@ -75,7 +75,7 @@
   margin-block-end: var(--spacing-global-block-end-small-screen);
   row-gap: 2rem;
 
-  @media (min-width: 22.5rem) {
+  @media (min-width: 36rem) {
     margin-block-end: var(--spacing-global-block-end-medium-screen);
   }
 
@@ -134,7 +134,7 @@
 
 /* adjust font sizes */
 .article-header {
-  @media (min-width: 22.5rem) {
+  @media (min-width: 36rem) {
     .article-header__eyebrow {
       font-size: var(--spectrum-detail-size-l);
     }

--- a/blocks/page-header/page-header.css
+++ b/blocks/page-header/page-header.css
@@ -89,7 +89,7 @@
 
 /* adjust font sizes */
 .page-header {
-  @media (min-width: 22.5rem) {
+  @media (min-width: 36rem) {
     h1 {
       font-size: var(--spectrum-heading-size-xl);
     }
@@ -106,6 +106,13 @@
   @media (min-width: 48rem) {
     .page-header__description--with-byline {
       font-size: var(--spectrum-title-size-l);
+    }
+  }
+
+  @media (min-width: 48rem) and (max-width:60rem) {
+    /* Reduce font size at the start of this breakpoint for the 50/50 layout. */
+    .page-header__content.grid-item.grid-item--50 h1 {
+      font-size: var(--spectrum-font-size-1200);
     }
   }
 

--- a/styles/base.css
+++ b/styles/base.css
@@ -466,7 +466,7 @@
   --spectrum-heading-size-s: var(--spectrum-font-size-700);
   --spectrum-heading-weight-s: var(--spectrum-extra-bold-font-weight);
 
-  @media (min-width: 22.5rem) {
+  @media (min-width: 36rem) {
     --spectrum-heading-size-xxl: var(--spectrum-font-size-1300);
     --spectrum-heading-size-xl: var(--spectrum-font-size-1200);
     --spectrum-heading-size-l: var(--spectrum-font-size-1000);


### PR DESCRIPTION
## Summary of changes
- Keep main heading font at a readable size at a wider range of mobile viewport sizes; the font was getting too large too soon, after `22.5rem`.
- Reduce font size at the start of the 50/50 article header breakpoint, as used on the homepage, as the larger font size did not have enough space, causing every word to be on its own line.

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-headline-sizes--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has visual changes, and has been reviewed by a designer.
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR has new code, so new tests were added or updated, and they pass.
* [ ] This PR affects production code, so it was browser tested (see below).
* [ ] This PR has copy changes, so copy was proofread and approved.
* [ ] The content of this PR requires documentation, so we added a detailed description of the component's purpose, requirements, quirks, and instructions for use by designers and developers. This includes accessibility information if pertinent.

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. Resize browser down on homepage and article pages. Check that original issues do not exist (~360px+ and 768px).

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [x] Chrome
* [ ] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
