### PR TITLE
fix: author names with dashes not appearing on articles

### DIFF
--- a/scripts/helpers/prepURL.js
+++ b/scripts/helpers/prepURL.js
@@ -1,6 +1,6 @@
 /**
  * Takes a URL string and prepares it to be used as a URL slug
- * by making it lower case, removing non-alphanumeric characters,
+ * by making it lower case, removing non-alphanumeric characters other than dashes,
  * and replacing spaces with dashes.
  * @function
  * @param {string} string - The piece of text to be translated
@@ -10,7 +10,7 @@
 export const prepURL = (string) => {
   const slug = string
     .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, '')
+    .replace(/[^a-z0-9\s-]/g, '')
     .trim()
     .replace(/\s+/g, "-");
   return slug;


### PR DESCRIPTION
## Summary of changes

**fix: author names with dashes not appearing on articles**
Fix the `prepURL` function so that it does not replace existing dashes. This was resulting in the wrong slug name for authors that have dashes in their names and causing the default author aside to appear.

## Relevant Links
- Story: [ADB-278](https://sparkbox.atlassian.net/browse/ADB-278)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-author-names--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR has new code, so new tests were added or updated, and they pass.

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. This article should show its author bio at the bottom:
  - `/ideas/designing-adobe-illustrator-s-rich-tooltips`
4. Other articles are still showing bios

---
