### PR TITLE
fix: remove display fixed from career cta for small viewport heights

### DIFF
--- a/styles/global-blocks.css
+++ b/styles/global-blocks.css
@@ -126,16 +126,23 @@
 
 .listing-cta {
   background: var(--color-background-highlighted-element);
-  position: fixed;
-  left: 0;
-  bottom: 0;
-  right: 0;
-  border-radius: 1.5rem 1.5rem 0 0;
+  border-radius: 1.5rem;
   padding: 1.5rem 1.25rem 2rem;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
   box-shadow: var(--drop-shadow-emphasized);
+  margin-block-start: 2.0rem;
+
+  /* Fixed at the bottom of the page, only if the screen is not too small (i.e. not mobile in landscape). */
+  @media (min-height: 40rem) {
+    position: fixed;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    border-radius: 1.5rem 1.5rem 0 0;
+    margin-block-start: 0;
+  }
 
   @media (min-width: 36rem) {
     padding: 1.5rem 2rem 2rem;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -60,15 +60,17 @@ body.js-no-scroll {
   height: var(--page-viewport-height);
 }
 
-body.js-has-sticky-footer {
-  margin-block-end: 8rem;
+@media (min-height: 40rem) {
+  body.js-has-sticky-footer {
+    margin-block-end: 8rem;
 
-  @media (min-width: 48rem) {
-    margin-block-end: 10rem;
-  }
+    @media (min-width: 48rem) {
+      margin-block-end: 10rem;
+    }
 
-  @media (min-width: 67.5rem) {
-    margin-block-end: 0;
+    @media (min-width: 67.5rem) {
+      margin-block-end: 0;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary of changes
Prevent fixed career CTA at bottom of screen from appearing when the screen height is too small, such as in landscape on a mobile device. This prevents the CTA from taking up too much of the screen. The CTA is still shown at the bottom of the page, in addition to also having another button at the top for the same action. This also improves the reported issue with 400% zoom.

## Relevant Links
- Story: [ADB-273](https://sparkbox.atlassian.net/browse/ADB-273)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-cta-size--adobe-design-website--adobe.aem.page/

## Checklist
* [x] This PR has code changes, and our linters still pass.
* [ ] This PR has new code, so new tests were added or updated, and they pass.
* [ ] This PR affects production code, so it was browser tested (see below).

## Validation
1. Visit testing link.
2. Confirm that CTA fixed to the bottom at `/careers/example-job-posting` is not appearing when the screen height is less than 40rem (640px). E.g. device simulator in landscape for common/listed mobile devices.
3. Confirm that when zooming to 400%, the CTA will not appear fixed.
4. Confirm that CTA when not fixed is still appearing at the bottom, fully rounded.

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [x] Firefox
* [x] Chrome
* [ ] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
