### PR TITLE
feat: use set aspect ratio for card images

### DIFF
--- a/styles/global-blocks.css
+++ b/styles/global-blocks.css
@@ -830,6 +830,7 @@ body.color-scheme-dark .search .search__results-container {
 }
 
 .card {
+  --card-image-aspect-ratio: 4 / 3;
   display: flex;
   flex-direction: column;
   box-shadow: var(--drop-shadow-emphasized);
@@ -838,6 +839,7 @@ body.color-scheme-dark .search .search__results-container {
   overflow: hidden;
 
   @container card-container (min-width: 28rem) {
+    --card-image-aspect-ratio: auto;
     flex-direction: row;
   }
 }
@@ -853,13 +855,17 @@ a.card:hover {
 }
 
 .card__image {
+  aspect-ratio: var(--card-image-aspect-ratio, auto);
+  overflow: hidden;
+  background: var(--spectrum-gray-75);
+
   @container card-container (min-width: 28rem) {
     order: 2;
     flex: 1 0 50%;
   }
 
   & img {
-    aspect-ratio: unset;
+    aspect-ratio: auto;
     display: block;
     height: 100%;
     width: 100%;


### PR DESCRIPTION
## Summary of changes

The card grid now handles both square and 4:3 aspect ratio images when they are used for articles. When the card grid item image and its content are stacked, a 4:3 aspect ratio with the `object-fit: cover` image within it is now used. The existing behavior remains for the breakpoints where the card image and its content are side by side. As a bonus, this change also improves how cards look while the images are loading in.

## Relevant Links
- Story: [ADB-289](https://sparkbox.atlassian.net/browse/ADB-289)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://feat-image-aspect-ratio--adobe-design-website--adobe.aem.page/

## Checklist
* [x] This PR has code changes, and our linters still pass.
* [x] This PR affects production code, so it was browser tested (see below).

## Validation
1. Visit testing link home page and Ideas page.
2. Test that the grid looks correct at all breakpoints on the homepage cards and Ideas page cards. When the image and its content are side by side for certain breakpoints, the existing behavior/visuals should remain the same.
3. For breakpoints when the image and its content are stacked, the square images for "Behind the design: Adobe Stock Customize" and "Elevating design..." should display at the same 4:3 aspect ratio as the other card images. All images should appear at the same aspect ratio at these breakpoints.
3. Loading improvement: you can more easily test improved loading visuals using the "disable cache" checkbox in the Network tab. You'll no longer see the image area drastically shifting when using filters on the Ideas page while the images are still loading, and a slight background color difference behind the image while it's loading.

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [x] Firefox
* [x] Chrome
* [x] Safari
* [x] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
