### PR TITLE
fix: allow jobs link list to have relative career links

### DIFF
--- a/blocks/link-list/link-list.js
+++ b/blocks/link-list/link-list.js
@@ -1,5 +1,17 @@
 import { isExternalURL } from '../../scripts/helpers/index.js';
 
+// Root directory name without slashes.
+const JOB_LISTING_ROOT = "careers";
+
+/**
+ * Check if HREF URL is to an internal job listing page.
+ * @param {string} url 
+ * @returns {boolean}
+ */
+const urlIsJobListing = (url) => {
+  return url.startsWith(`https://adobe.design/${JOB_LISTING_ROOT}/`) || url.startsWith(`/${JOB_LISTING_ROOT}/`);
+};
+
 /**
  * Creates a decorated set of link list items.
  * @param {string} textContent the desired link text
@@ -29,7 +41,7 @@ const buildLinkListItem = ({ textContent, url, altText }) => {
     itemContent.append(itemContentPart);
   });
 
-  if (url.startsWith("https://adobe.design/careers/")) {
+  if (urlIsJobListing(url)) {
     itemContent.children[0].className = "link-list-item__job-title";
     itemContent.children[1].className =
       "link-list-item__job-department";
@@ -81,8 +93,10 @@ export default async function decorate(block) {
     altText: block.children[0]?.children[2]?.innerText,
   };
 
-  if (linksData.every((link) => link.url.startsWith("https://adobe.design/careers/")))
+  if (linksData.every((link) => urlIsJobListing(link.url))) {
     linkList.classList.add("link-list--jobs");
+  }
+
   linksData.forEach((row) => {
     const linkListItem = buildLinkListItem(row);
     linkList.append(linkListItem);


### PR DESCRIPTION
## Summary of changes

The job link list, which has a variant class and different content classes that make it appear as a different 2 column layout, was relying on all link list links starting with the domain name. Allow root relative linking for this logic, which will help with previewing the in progress content migration. In the future we may want to use another technique so the application of the jobs list styling is through an option and generally less fragile by relying on the URL.

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-jobs-list-relative-links--adobe-design-website--adobe.aem.page/

## Validation
1. Using a relative job listing link starting with `/careers/` does not change the jobs link list to a different layout. This content is in `partials/jobs-list`. It should still be styled as two columns with job details styling (additional classes that are applied when it determines all of the links are to jobs).

---
