### PR TITLE
feat: adobe analytics script migration [MERGE POST LAUNCH]

### DIFF
--- a/404.html
+++ b/404.html
@@ -73,6 +73,7 @@
 
     build404Page();
   </script>
+  <script src="https://assets.adobedtm.com/a7d65461e54e/9ee19a80de10/launch-882c01867cbb.min.js" async></script>
   <style>
     .not-found__heading {
       font-family: var(--spectrum-display-font);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -217,16 +217,18 @@ const setCalculatedPerspective = () => {
  * without impacting the user experience.
  */
 function loadDelayed() {
-  // eslint-disable-next-line import/no-cycle
-  window.setTimeout(() => import('./delayed.js'), 3000);
-  // load anything that can be postponed to the latest here
-  loadCSS(`${window.hlx.codeBasePath}/styles/delayed-styles.css`);
+  setTimeout(() => {
+    // Adobe analytics.
+    loadScript('https://assets.adobedtm.com/a7d65461e54e/9ee19a80de10/launch-882c01867cbb.min.js');
+  }, 4000);
+
+  // loadCSS(`${window.hlx.codeBasePath}/styles/delayed-styles.css`);
 }
 
 async function loadPage() {
   await loadEager(document);
   await loadLazy(document);
-  // loadDelayed();
+  loadDelayed();
 }
 
 loadPage();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -221,8 +221,6 @@ function loadDelayed() {
     // Adobe analytics.
     loadScript('https://assets.adobedtm.com/a7d65461e54e/9ee19a80de10/launch-882c01867cbb.min.js');
   }, 4000);
-
-  // loadCSS(`${window.hlx.codeBasePath}/styles/delayed-styles.css`);
 }
 
 async function loadPage() {


### PR DESCRIPTION
## Summary of changes

**Add loading of Adobe analytics script**
Brings over the Adobe analytics script, with its same method of delayed loading, from the [previous site's code](https://github.com/search?q=repo%3Aadobe%2Fdesign-website%20https%3A%2F%2Fassets.adobedtm.com&type=code).

## Relevant Links
- Story: [ADB-306](https://sparkbox.atlassian.net/browse/ADB-306)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-adb-306--adobe-design-website--adobe.aem.page/

## Checklist
* [x] This PR has code changes, and our linters still pass.
* [ ] This PR affects production code, so it was browser tested (see below).

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. Analytics code is in the `<head>` of all pages, including 404.

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [ ] Chrome
* [ ] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
