### PR TITLE
fix: card focus rounding

### DIFF
--- a/styles/global-blocks.css
+++ b/styles/global-blocks.css
@@ -859,6 +859,11 @@ body.color-scheme-dark .search .search__results-container {
   }
 }
 
+a.card {
+  /* Ensure base focus styles are overridden. */
+  border-radius: 1rem;
+}
+
 a.card:hover {
   color: var(--color-text);
   cursor: pointer;


### PR DESCRIPTION
## Summary of changes

Fix a bug where corner rounding on the card component changes to the wrong (smaller) rounding only on the first newly loaded card after loading more articles on the Ideas page. This was also noticed as being reproducible by click and dragging a card. The incorrect rounding would disappear immediately when inspecting the element in Chrome. This was due to some general base focus styles that applied to the `focus` and `focus-visible` of anchors.

## Relevant Links
- Story: [ADB-257](https://sparkbox.atlassian.net/browse/ADB-257)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-card-focus-rounding--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has visual changes, and has been reviewed by a designer.
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR has new code, so new tests were added or updated, and they pass.
* [ ] This PR affects production code, so it was browser tested (see below).
* [ ] This PR has copy changes, so copy was proofread and approved.
* [ ] The content of this PR requires documentation, so we added a detailed description of the component's purpose, requirements, quirks, and instructions for use by designers and developers. This includes accessibility information if pertinent.

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches or visit PR link
3. Load more articles on Ideas page. First newly loaded card should not have a different border radius.
4. Clicking and dragging a card link (Chrome) does not show a different border radius.

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [x] Chrome
* [x] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
