### PR TITLE
feat: who we are page header

### DIFF
--- a/assets/themes/shapes.js
+++ b/assets/themes/shapes.js
@@ -112,7 +112,6 @@ export const wavesAndGlow =
 export const fade =
 `<svg class="shape shape--fade" width="1426" height="587" viewBox="0 0 1426 587" fill="none" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice">
   <g clip-path="url(#fadeClip">
-    <rect width="1426" height="587" fill="light-dark(var(--spectrum-gray-25, #FFFFFF), var(--spectrum-gray-25, #111111))"/>
     <g opacity="0.6" filter="url(#filterBlur)">
       <path d="M1642.25 1343.38C1782.6 936.29 1840.42 123.806 1431.73 136.139C1023.04 148.472 1094.89 1099.13 842.266 1160.89C526.482 1238.1 91.4015 887.158 -189.295 641.497C-469.992 395.837 -561.219 269.497 -799.811 199.309C-1038.4 129.12 -1515.59 430.931 -1733.13 795.913C-1950.67 1160.89 -1543.66 2290.93 -701.567 2466.4C140.523 2641.88 1501.9 1750.48 1642.25 1343.38Z" fill="light-dark(var(--spectrum-indigo-1000, #6338EE), var(--spectrum-indigo-1000, #8B8DFE))"/>
     </g>

--- a/assets/themes/shapes.js
+++ b/assets/themes/shapes.js
@@ -113,7 +113,7 @@ export const fade =
 `<svg class="shape shape--fade" width="1426" height="587" viewBox="0 0 1426 587" fill="none" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice">
   <g clip-path="url(#fadeClip">
     <g opacity="0.6" filter="url(#filterBlur)">
-      <path d="M1642.25 1343.38C1782.6 936.29 1840.42 123.806 1431.73 136.139C1023.04 148.472 1094.89 1099.13 842.266 1160.89C526.482 1238.1 91.4015 887.158 -189.295 641.497C-469.992 395.837 -561.219 269.497 -799.811 199.309C-1038.4 129.12 -1515.59 430.931 -1733.13 795.913C-1950.67 1160.89 -1543.66 2290.93 -701.567 2466.4C140.523 2641.88 1501.9 1750.48 1642.25 1343.38Z" fill="light-dark(var(--spectrum-indigo-1000, #6338EE), var(--spectrum-indigo-1000, #8B8DFE))"/>
+      <path d="M1642.25 1343.38C1782.6 936.29 1840.42 123.806 1431.73 136.139C1023.04 148.472 1094.89 1099.13 842.266 1160.89C526.482 1238.1 91.4015 887.158 -189.295 641.497C-469.992 395.837 -561.219 269.497 -799.811 199.309C-1038.4 129.12 -1515.59 430.931 -1733.13 795.913C-1950.67 1160.89 -1543.66 2290.93 -701.567 2466.4C140.523 2641.88 1501.9 1750.48 1642.25 1343.38Z" fill="var(--spectrum-indigo-1000, #6338EE)"/>
     </g>
     <g opacity="0.9" filter="url(#filterBlur)">
       <path d="M859.539 57.6609C678.414 189.083 754.157 317.22 938.575 491.355C1059.33 620.588 1362.74 873.795 1610.38 852.767C1919.94 826.483 1755.28 718.059 1580.75 632.635C1406.21 547.21 1376.57 491.355 1363.4 363.218C1350.22 235.081 1452.31 235.081 1564.28 -17.907C1676.25 -270.895 1531.35 -543.597 1402.91 -533.74C1274.48 -523.884 1462.19 -431.888 1323.88 -221.612C1185.56 -11.3359 1040.66 -73.7616 859.539 57.6609Z" fill="url(#fadeLinearGradient)"/>
@@ -126,9 +126,9 @@ export const fade =
       <feGaussianBlur stdDeviation="159.04" result="effect1_foregroundBlur_4971_97"/>
     </filter>
     <linearGradient id="fadeLinearGradient" x1="902.035" y1="413.032" x2="1629.54" y2="-172.627" gradientUnits="userSpaceOnUse">
-      <stop stop-color="light-dark(var(--spectrum-cyan-400, #8AD5FF), var(--spectrum-cyan-400, #004058))"/>
-      <stop offset="0.509615" stop-color="light-dark(var(--spectrum-pink-400, #FFB5E6), var(--spectrum-pink-400, #73074B))"/>
-      <stop offset="1" stop-color="light-dark(var(--spectrum-red-700, #FF513D), var(--spectrum-red-700, #CD2E1D))"/>
+      <stop stop-color="var(--spectrum-cyan-400, #8AD5FF)"/>
+      <stop offset="0.509615" stop-color="var(--spectrum-pink-400, #FFB5E6)"/>
+      <stop offset="1" stop-color="var(--spectrum-red-700, #FF513D)"/>
     </linearGradient>
     <clipPath id="fadeClip">
       <rect width="1426" height="587" fill="transparent"/>

--- a/assets/themes/shapes.js
+++ b/assets/themes/shapes.js
@@ -1,8 +1,8 @@
 /**
- * @file SVG strings for the page header backgrounds. 
+ * @file SVG strings for the page header backgrounds.
  */
 
-export const roundedDiamond = 
+export const roundedDiamond =
 `<svg role="presentation" class="shape shape--diamond" width="1292" height="895" viewBox="0 0 1292 895" fill="none" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
     <g opacity="0.56">
         <mask id="mask0_2047_12900" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="-114" width="2823" height="1826">
@@ -20,7 +20,7 @@ export const roundedDiamond =
     </defs>
 </svg>`;
 
-export const slopes = 
+export const slopes =
 `<svg class="shape shape--slopes" width="2183" height="900" viewBox="0 0 2183 900" fill="none" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
     <mask id="mask0_2675_5947" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="297" y="-1178" width="1986" height="1544">
         <ellipse cx="992.547" cy="771.748" rx="992.547" ry="771.748" transform="matrix(0.999995 -0.00289327 0.00607683 0.999985 293.028 -1174.9)" fill="url(#paint0_radial_2675_5947)"/>
@@ -60,7 +60,7 @@ export const slopes =
     </defs>
 </svg>`;
 
-export const fadedWave = 
+export const fadedWave =
 `<svg class="shape shape--faded-wave" width="1453" height="592" viewBox="0 0 1453 592" fill="none" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
     <g opacity="0.33">
         <mask id="mask0_2047_13068" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="2471" height="1109">
@@ -78,7 +78,7 @@ export const fadedWave =
     </defs>
 </svg>`;
 
-export const wavesAndGlow = 
+export const wavesAndGlow =
 `<svg class="shape shape--waves-and-glow" width="1616" height="876" viewBox="0 0 1616 876" fill="none" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
     <path d="M625.077 -556.806C733.711 -524.751 819.132 -451.719 869.434 -359.719C969.967 -175.476 1088.06 -140.496 1272.44 -240.406C1364.74 -290.726 1476.28 -305.772 1585.04 -273.681C1802.39 -209.414 1926.64 18.2916 1862.63 235.235C1798.61 452.178 1570.69 575.836 1353.3 511.69C1244.3 479.528 1158.83 406.216 1108.63 313.851C1008.08 130.13 890.03 95.4301 705.581 195.583C613.356 245.66 502.006 260.498 393.372 228.444C176.104 164.334 51.8564 -63.3716 115.834 -280.193C179.812 -497.015 407.809 -620.916 625.077 -556.806Z" fill="url(#paint0_linear_2716_6071)" fill-opacity="0.5"/>
     <mask id="mask0_2716_6071" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="835" y="-616" width="1492" height="1492">
@@ -109,9 +109,38 @@ export const wavesAndGlow =
     </defs>
 </svg>`;
 
+export const fade =
+`<svg class="shape shape--fade" width="1426" height="587" viewBox="0 0 1426 587" fill="none" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice">
+  <g clip-path="url(#fadeClip">
+    <rect width="1426" height="587" fill="light-dark(var(--spectrum-gray-25, #FFFFFF), var(--spectrum-gray-25, #111111))"/>
+    <g opacity="0.6" filter="url(#filterBlur)">
+      <path d="M1642.25 1343.38C1782.6 936.29 1840.42 123.806 1431.73 136.139C1023.04 148.472 1094.89 1099.13 842.266 1160.89C526.482 1238.1 91.4015 887.158 -189.295 641.497C-469.992 395.837 -561.219 269.497 -799.811 199.309C-1038.4 129.12 -1515.59 430.931 -1733.13 795.913C-1950.67 1160.89 -1543.66 2290.93 -701.567 2466.4C140.523 2641.88 1501.9 1750.48 1642.25 1343.38Z" fill="light-dark(var(--spectrum-indigo-1000, #6338EE), var(--spectrum-indigo-1000, #8B8DFE))"/>
+    </g>
+    <g opacity="0.9" filter="url(#filterBlur)">
+      <path d="M859.539 57.6609C678.414 189.083 754.157 317.22 938.575 491.355C1059.33 620.588 1362.74 873.795 1610.38 852.767C1919.94 826.483 1755.28 718.059 1580.75 632.635C1406.21 547.21 1376.57 491.355 1363.4 363.218C1350.22 235.081 1452.31 235.081 1564.28 -17.907C1676.25 -270.895 1531.35 -543.597 1402.91 -533.74C1274.48 -523.884 1462.19 -431.888 1323.88 -221.612C1185.56 -11.3359 1040.66 -73.7616 859.539 57.6609Z" fill="url(#fadeLinearGradient)"/>
+    </g>
+  </g>
+  <defs>
+    <filter id="filterBlur" x="437.919" y="-852.081" width="1664.16" height="2024.16" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+      <feGaussianBlur stdDeviation="159.04" result="effect1_foregroundBlur_4971_97"/>
+    </filter>
+    <linearGradient id="fadeLinearGradient" x1="902.035" y1="413.032" x2="1629.54" y2="-172.627" gradientUnits="userSpaceOnUse">
+      <stop stop-color="light-dark(var(--spectrum-cyan-400, #8AD5FF), var(--spectrum-cyan-400, #004058))"/>
+      <stop offset="0.509615" stop-color="light-dark(var(--spectrum-pink-400, #FFB5E6), var(--spectrum-pink-400, #73074B))"/>
+      <stop offset="1" stop-color="light-dark(var(--spectrum-red-700, #FF513D), var(--spectrum-red-700, #CD2E1D))"/>
+    </linearGradient>
+    <clipPath id="fadeClip">
+      <rect width="1426" height="587" fill="transparent"/>
+    </clipPath>
+  </defs>
+</svg>`;
+
 export const allShapes = {
     roundedDiamond,
     slopes,
     fadedWave,
     wavesAndGlow,
+    fade,
 };

--- a/blocks/page-header/page-header.css
+++ b/blocks/page-header/page-header.css
@@ -167,3 +167,21 @@
     }
   }
 }
+
+.page-header--constrained {
+  --page-constrained-text: 100%;
+
+  max-width: 60.125rem;
+  margin: auto;
+
+  &:not(:has(.page-header__image, .page-header__video)) {
+    .page-header__content.grid-item.grid-item--50 {
+      grid-column: span 12;
+      max-width: var(--page-constrained-text);
+    }
+  }
+
+  .page-header__title {
+    font-size: var(--heading-size-xxl);
+  }
+}

--- a/blocks/page-header/page-header.css
+++ b/blocks/page-header/page-header.css
@@ -182,11 +182,6 @@
   }
 
   .page-header__title {
-    font-size: var(--heading-size-xxxl) !important;
     margin-block: var(--spectrum-spacing-500) var(--spectrum-spacing-400);
-  }
-
-  .page-header__description {
-    font-size: var(--body-size-xl) !important;
   }
 }

--- a/blocks/page-header/page-header.css
+++ b/blocks/page-header/page-header.css
@@ -172,7 +172,7 @@
   --page-constrained-text: 100%;
 
   max-width: 60.125rem;
-  margin: auto;
+  margin-inline: auto;
 
   &:not(:has(.page-header__image, .page-header__video)) {
     .page-header__content.grid-item.grid-item--50 {
@@ -182,6 +182,11 @@
   }
 
   .page-header__title {
-    font-size: var(--heading-size-xxl);
+    font-size: var(--heading-size-xxxl) !important;
+    margin-block: var(--spectrum-spacing-500) var(--spectrum-spacing-400);
+  }
+
+  .page-header__description {
+    font-size: var(--body-size-xl) !important;
   }
 }

--- a/blocks/page-header/page-header.js
+++ b/blocks/page-header/page-header.js
@@ -9,12 +9,18 @@ export default async function decorate(block) {
     anchorNode: block.children?.[4]?.children?.[0]?.firstChild?.firstChild,
     buttonStyle: block.children?.[4]?.children?.[1]?.children?.[0]?.textContent?.trim().toLowerCase(),
     altText: block.children?.[4]?.children?.[2]?.children?.[0]?.textContent?.trim(),
+    additionalClasses: block.children?.[5]?.children?.[0]?.textContent.split(" "),
   };
   const anchorHref = pageHeaderData.anchorNode?.href;
+  const classes = ["grid-container", "page-header"];
+
+  if (pageHeaderData.additionalClasses) {
+    classes.push(...pageHeaderData.additionalClasses);
+  }
 
   // create the container element
   const pageHeader = document.createElement("div");
-  pageHeader.classList.add("grid-container", "page-header");
+  pageHeader.classList.add(...classes);
 
   const pageHeaderContent = document.createElement("div");
   pageHeaderContent.classList.add("page-header__content", "grid-item", "grid-item--50");

--- a/blocks/page-header/page-header.js
+++ b/blocks/page-header/page-header.js
@@ -23,7 +23,7 @@ export default async function decorate(block) {
   const pageTitle = document.createElement("h1");
   pageTitle.classList.add("page-header__title", "util-heading-xl");
 
-  if (pageHeaderData.anchorNode && !anchorHref.includes("#")) {
+  if (pageHeaderData.anchorNode && !anchorHref.includes("#") && pageHeaderData.visual) {
     // If there's a link to another page, include an anchor within the title.
     const wrappingAnchor = document.createElement("a");
     wrappingAnchor.setAttribute("href", anchorHref);

--- a/scripts/helpers/themeBackgrounds.js
+++ b/scripts/helpers/themeBackgrounds.js
@@ -3,10 +3,10 @@ import { allShapes } from "../../assets/themes/shapes.js";
 /**
  * Adds inline SVGs needed for the unique page backgrounds within some themes.
  * Appends a container element containing the SVG element(s).
- * 
+ *
  * These are added as their own elements instead of in `background-image` because their
  * fill colors are changed with CSS between themes and light/dark.
- * 
+ *
  * @param {string} theme - The name of the current theme (as stored in metadata).
  */
 export async function decorateThemeBackgroundVisuals(theme) {
@@ -19,7 +19,8 @@ export async function decorateThemeBackgroundVisuals(theme) {
         'backdrop-green': [allShapes.roundedDiamond],
         'backdrop-seafoam': [allShapes.fadedWave],
         'backdrop-blue-green-wave': [allShapes.wavesAndGlow],
-        'backdrop-blue-circles': [allShapes.slopes]
+        'backdrop-blue-circles': [allShapes.slopes],
+        'backdrop-blue-purple-fade': [allShapes.fade]
     };
 
     // Return if theme does not need any SVGs.

--- a/styles/base.css
+++ b/styles/base.css
@@ -458,6 +458,9 @@
   --heading-font-family: var(--spectrum-display-font);
   --heading-line-height: 1.25;
 
+  --heading-size-xxxl: var(--spectrum-font-size-1100);
+  --spectrum-heading-weight-xxxl: var(--spectrum-extra-bold-font-weight);
+
   --heading-size-xxl: var(--spectrum-font-size-1000);
   --spectrum-heading-weight-xxl: var(--spectrum-extra-bold-font-weight);
 
@@ -474,6 +477,7 @@
   --spectrum-heading-weight-s: var(--spectrum-extra-bold-font-weight);
 
   @media (min-width: 36rem) {
+    --heading-size-xxxl: var(--spectrum-font-size-1200);
     --heading-size-xxl: var(--spectrum-font-size-1100);
     --heading-size-xl: var(--spectrum-font-size-1000);
     --heading-size-l: var(--spectrum-font-size-900);
@@ -482,6 +486,7 @@
   }
 
   @media (min-width: 48rem) {
+    --heading-size-xxxl: var(--spectrum-font-size-1400);
     --heading-size-xxl: var(--spectrum-font-size-1300);
     --heading-size-xl: var(--spectrum-font-size-1200);
     --heading-size-l: var(--spectrum-font-size-1000);
@@ -490,6 +495,7 @@
   }
 
   @media (min-width: 80rem) {
+    --heading-size-xxxl: var(--spectrum-font-size-1500);
     --heading-size-xxl: var(--spectrum-font-size-1400);
     --heading-size-xl: var(--spectrum-font-size-1300);
     --heading-size-l: var(--spectrum-font-size-1100);

--- a/styles/base.css
+++ b/styles/base.css
@@ -458,9 +458,6 @@
   --heading-font-family: var(--spectrum-display-font);
   --heading-line-height: 1.25;
 
-  --heading-size-xxxl: var(--spectrum-font-size-1100);
-  --spectrum-heading-weight-xxxl: var(--spectrum-extra-bold-font-weight);
-
   --heading-size-xxl: var(--spectrum-font-size-1000);
   --spectrum-heading-weight-xxl: var(--spectrum-extra-bold-font-weight);
 
@@ -477,7 +474,6 @@
   --spectrum-heading-weight-s: var(--spectrum-extra-bold-font-weight);
 
   @media (min-width: 36rem) {
-    --heading-size-xxxl: var(--spectrum-font-size-1200);
     --heading-size-xxl: var(--spectrum-font-size-1100);
     --heading-size-xl: var(--spectrum-font-size-1000);
     --heading-size-l: var(--spectrum-font-size-900);
@@ -486,7 +482,6 @@
   }
 
   @media (min-width: 48rem) {
-    --heading-size-xxxl: var(--spectrum-font-size-1400);
     --heading-size-xxl: var(--spectrum-font-size-1300);
     --heading-size-xl: var(--spectrum-font-size-1200);
     --heading-size-l: var(--spectrum-font-size-1000);
@@ -495,7 +490,6 @@
   }
 
   @media (min-width: 80rem) {
-    --heading-size-xxxl: var(--spectrum-font-size-1500);
     --heading-size-xxl: var(--spectrum-font-size-1400);
     --heading-size-xl: var(--spectrum-font-size-1300);
     --heading-size-l: var(--spectrum-font-size-1100);

--- a/styles/base.css
+++ b/styles/base.css
@@ -124,8 +124,11 @@
 
   --spectrum-turquoise-200: rgb(209 245 245);
 
+  --spectrum-pink-400: rgb(255 181 230);
+
   --spectrum-red-500: rgb(255 157 145);
   --spectrum-red-600: rgb(255 118 101);
+  --spectrum-red-700: rgb(255 81 61);
   --spectrum-red-1400: rgb(80 16 6);
 
   --spectrum-brown-1400: rgb(52 37 13);
@@ -186,8 +189,11 @@
 
     --spectrum-turquoise-200: rgb(0 37 41);
 
+    --spectrum-pink-400: rgb(115 7 75);
+
     --spectrum-red-500: rgb(147 31 17);
     --spectrum-red-600: rgb(177 38 23);
+    --spectrum-red-700: rgb(205 46 29);
     --spectrum-red-1400: rgb(255 222 219);
 
     --spectrum-brown-1400: rgb(242 227 206);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -596,11 +596,11 @@ main > .section.small-screen-cta-container > .grid-container:has(+ .call-to-acti
 .grid-container--with-scroll {
   --card-drop-shadow-size-x: var(--spectrum-drop-shadow-blur-100);
   --card-drop-shadow-size-y: calc(var(--spectrum-drop-shadow-y-100) + var(--spectrum-drop-shadow-blur-100));
- 
+
   padding-block: var(--card-drop-shadow-size-y);
   padding-inline-start: var(--card-drop-shadow-size-x);
   margin-inline-start: calc(var(--card-drop-shadow-size-x) * -1);
- 
+
   @media not all and (min-width: 36rem) {
     overflow-x: scroll;
     margin-inline-end: calc(var(--page-gutters) * -1);
@@ -1310,5 +1310,14 @@ main > .section.small-screen-cta-container > .grid-container:has(+ .call-to-acti
         width: calc(50dvw + 800px);
       }
     }
+  }
+}
+
+.theme--backdrop-blue-purple-fade {
+  --page-background-height: 100%;
+
+  .shape {
+    width: 100%;
+    height: 100%;
   }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1314,7 +1314,15 @@ main > .section.small-screen-cta-container > .grid-container:has(+ .call-to-acti
 }
 
 .theme--backdrop-blue-purple-fade {
-  --page-background-height: 100%;
+  --page-background-height: 100dvh;
+
+  @media (min-width: 48rem) {
+    --page-background-height: 37.5rem;
+  }
+
+  @media (min-width: 105rem) {
+    --page-background-height: 40rem;
+  }
 
   .shape {
     width: 100%;


### PR DESCRIPTION
## Summary of changes
This pull request updates the _Who We Are_  page header with:
- a new blue-purple-fade theme for the page header with light and dark variants
- adds an option to add utility and modifier classes to the parent page-header element
  - Updated documentation can be found in the pattern library
- Adds styles for the `.page-header--constrained` modifier

## Relevant Links
- Designs: [Figma](https://www.figma.com/design/mf1X2eC29hxagQcYF2juqW/WIP_Adobe.design?node-id=4980-115&t=Z709Kowt0dTcfufR-4)
- Story: [ADB-305](https://sparkbox.atlassian.net/browse/ADB-305)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://feat-adb-305-who-we-are-header--adobe-design-website--adobe.aem.page/

## Checklist
<!-- Delete anything irrelevant to this PR -->
* [ ] This PR has visual changes, and has been reviewed by a designer.
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR has new code, so new tests were added or updated, and they pass.
* [ ] This PR affects production code, so it was browser tested (see below).
* [ ] This PR has copy changes, so copy was proofread and approved.
* [ ] The content of this PR requires documentation, so we added a detailed description of the component's purpose, requirements, quirks, and instructions for use by designers and developers. This includes accessibility information if pertinent.

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
<!-- Add additional validation steps here -->

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [ ] Chrome
* [ ] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
