### PR TITLE
fix: search toggle - correct aria attributes and safari icon alignment

### DIFF
--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -214,6 +214,7 @@ function createSearchResultsContainer() {
 function createSearchBox(block, config) {
   const box = document.createElement('div');
   box.classList.add('search__box');
+  box.id = 'nav-search';
 
   // Wrapper that holds search icon, input, and clear button.
   const inputWrapper = document.createElement('div');
@@ -235,6 +236,8 @@ function createSearchBox(block, config) {
   toggleButton.classList.add('search__button');
   toggleButton.setAttribute('type', 'button');
   toggleButton.setAttribute('aria-label', DEFAULT_CONTENT.toggleAriaLabel);
+  toggleButton.setAttribute('aria-expanded', 'false');
+  toggleButton.setAttribute('aria-controls', 'nav-search');
   toggleButton.innerHTML = SEARCH_INPUT_ICON;
 
   // Search overlay results
@@ -260,9 +263,10 @@ function createSearchBox(block, config) {
    * Clicking the search icon toggles the expanded search field.
    */
   toggleButton.addEventListener('click', () => {
-    box.classList.toggle('search__box--expanded');
-    toggleButton.toggleAttribute('aria-expanded');
-    if (box.classList.contains('search__box--expanded')) {
+    const isExpanding = !box.classList.contains('search__box--expanded');
+    box.classList.toggle('search__box--expanded', isExpanding);
+    toggleButton.setAttribute('aria-expanded', isExpanding ? 'true' : 'false');
+    if (isExpanding) {
       searchInput.focus();
     } else {
       clearSearchResults(block);

--- a/styles/global-blocks.css
+++ b/styles/global-blocks.css
@@ -430,7 +430,7 @@
     display: block;
     color: var(--spectrum-gray-600);
 
-    em {
+    & em {
       font-style: normal;
     }
 
@@ -661,6 +661,7 @@
 
     & svg {
       flex: 1 0 auto;
+      max-width: 100%;
     }
 
     .nav--large-screens & {


### PR DESCRIPTION
## Summary of changes

Add `aria-controls` and the corrected values for `aria-expanded` on the main navigation toggle search button, so the button is properly announced as expanded or collapsed.

<img width="562" height="208" alt="Screenshot 2026-04-03 at 4 01 30 PM" src="https://github.com/user-attachments/assets/8b9c2476-3246-45da-bd24-40f558035880" />
<img width="379" height="181" alt="Screenshot 2026-04-03 at 4 00 34 PM" src="https://github.com/user-attachments/assets/cc2cba5a-63c5-42c0-95fd-cece3dca03b3" />

Also adds a CSS fix for Safari's alignment of the search icon (existing issue), noticed during browser testing:
<img width="80" height="76" alt="Screenshot 2026-04-03 at 5 03 30 PM" src="https://github.com/user-attachments/assets/04ca6407-4cba-43b6-91c2-3ffbef722ec5" />

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-a11y-search-toggle--adobe-design-website--adobe.aem.page/

## Checklist
* [x] This PR has code changes, and our linters still pass.
* [ ] This PR has new code, so new tests were added or updated, and they pass.
* [ ] This PR affects production code, so it was browser tested (see below).
* [ ] This PR has copy changes, so copy was proofread and approved.
* [ ] The content of this PR requires documentation, so we added a detailed description of the component's purpose, requirements, quirks, and instructions for use by designers and developers. This includes accessibility information if pertinent.

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. Confirm screen reader announcement of collapsed and expanded on search toggle button.
4. Confirm existence and values of `aria-controls` and `aria-expanded` on search toggle button.
5. Confirm CSS fix for search icon alignment in Safari.
---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [x] Chrome
* [x] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
