### PR TITLE
fix: script import for adb-306

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -14,6 +14,7 @@ import {
   loadSection,
   loadSections,
   loadCSS,
+  loadScript,
   sampleRUM,
 } from './aem.js';
 import {


### PR DESCRIPTION
## Summary of changes
Add missing `loadScript` import for ADB-306 update.

## Relevant Links
- Story: [ADB-306](https://sparkbox.atlassian.net/browse/ADB-306)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-adb-306--adobe-design-website--adobe.aem.page/

## Validation
1. Analytics script appears in head after page load, and no related console import error.

---
