### PR TITLE
fix: unnecessary horizontal scrollbars when user has classic scrollbars

### DIFF
--- a/blocks/responsive-split-layout/responsive-split-layout.css
+++ b/blocks/responsive-split-layout/responsive-split-layout.css
@@ -3,7 +3,7 @@
   --split-layout-content-spacing: 0.5rem;
   --split-layout-column-gap: 1.25rem;
 
-  width: 100vw;
+  width: 100cqw;
   margin-inline: calc(-1 * var(--page-gutters));
 
   @media (min-width: 48rem) {
@@ -20,7 +20,7 @@
   @media (min-width: 105rem) {
     --split-layout-spacing: 5rem;
     --split-layout-column-gap: 12.625rem;
-    margin-inline: calc(-0.5 * calc(100vw - var(--page-max-width)));
+    margin-inline: calc(-0.5 * calc(100cqw - var(--page-max-width)));
   }
 
   /* 

--- a/styles/global-blocks.css
+++ b/styles/global-blocks.css
@@ -130,11 +130,11 @@
 }
 
 .horizontal-rule--full {
-  width: 100vw;
+  width: 100cqw;
   margin-inline: calc(-1 * var(--page-gutters));
 
   @media (min-width: 105.5rem) {
-    margin-inline: calc(-0.5 * calc(100vw - var(--page-max-width)));
+    margin-inline: calc(-0.5 * calc(100cqw - var(--page-max-width)));
   }
 }
 
@@ -492,7 +492,7 @@
 }
 
 .image-with-caption--full-bleed {
-  width: 100vw;
+  width: 100cqw;
   transform: translateX(calc(var(--page-gutters) * -1));
 
   & .image-with-caption__image img {
@@ -515,7 +515,7 @@
     transform: none;
 
     & .image-with-caption__image img {
-      width: calc(100vw - 4rem);
+      width: calc(100cqw - 4rem);
       max-width: 66rem;
       margin-inline-start: 50%;
       transform: translateX(-50%);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -81,6 +81,9 @@ body.color-scheme-dark {
 
 main {
   padding-block-start: 4rem;
+  /* Set as a query container to allow our full-bleed components to use `cqw` units (to account for scrollbars). */
+  container-type: inline-size;
+  container-name: site-main;
 }
 
 main > .section {


### PR DESCRIPTION
## Summary of changes

Fixes issue with full-bleed elements creating unnecessary horizontal scrollbars for users with classic scrollbars (Windows users and MacOS users with OS Appearance setting "Show scrollbars: Always"). `100vw` does not account for the width of the non-overlay vertical scrollbar.

This updates the CSS of the full-bleed elements relying on `100vw` to use the `cqw` unit instead, along with a query container on the main element. This workaround has was more browser support currently in older Safari versions than `scrollbar-gutter: stable` and avoids a JavaScript dependent width calculation. <sup>[[1]](https://www.smashingmagazine.com/2023/12/new-css-viewport-units-not-solve-classic-scrollbar-problem/#solving-the-classic-scrollbar-problem)</sup> <sup>[[2]](https://caniuse.com/mdn-css_types_length_container_query_length_units)</sup> <sup>[[3]](https://caniuse.com/wf-scrollbar-gutter)</sup>

Components affected: Article page horizontal rule before footer, article header image, and Who We Are page split layout.

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-hr-scrollbars--adobe-design-website--adobe.aem.page/

## Checklist
<!-- Delete anything irrelevant to this PR -->
* [ ] This PR has visual changes, and has been reviewed by a designer.
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR has new code, so new tests were added or updated, and they pass.
* [ ] This PR affects production code, so it was browser tested (see below).
* [ ] This PR has copy changes, so copy was proofread and approved.
* [ ] The content of this PR requires documentation, so we added a detailed description of the component's purpose, requirements, quirks, and instructions for use by designers and developers. This includes accessibility information if pertinent.

## Validation
Test on either Windows or in in MacOS, change the setting to "Always" in System Settings > Appearance > Show scroll bars

1. Make sure all PR checks have passed.
2. Extra horizontal scrollbars do not appear on Article (Ideas) pages and on Who We Are page. Also check the pattern library.
3. Site otherwise looks the same.

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [x] Firefox
* [x] Chrome
* [x] Safari
* [x] Edge

**Android**
* [x] Firefox
* [x] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
