### PR TITLE
feat: change default link style to secondary variant

### DIFF
--- a/blocks/callout/callout.css
+++ b/blocks/callout/callout.css
@@ -74,13 +74,16 @@
 }
 
 .callout--with-link {
+  text-decoration-line: none;
+
   &:hover {
     color: var(--spectrum-white);
-    text-decoration: none;
-  }
+    text-decoration-line: none;
 
-  &:hover .callout__title {
-    text-decoration: underline;
+    & .callout__title {
+      text-decoration: underline var(--link-underline-thickness);
+      text-underline-offset: var(--link-underline-thickness);
+    }
   }
 }
 

--- a/blocks/footer-copyright/footer-copyright.css
+++ b/blocks/footer-copyright/footer-copyright.css
@@ -13,5 +13,10 @@
 
   & a {
     color: var(--spectrum-gray-600);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }

--- a/blocks/footer-links/footer-links.css
+++ b/blocks/footer-links/footer-links.css
@@ -15,6 +15,11 @@
 
   & a {
     color: var(--spectrum-gray-700);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }
 

--- a/blocks/form/form.css
+++ b/blocks/form/form.css
@@ -84,7 +84,7 @@
 .form input:focus,
 .form select:focus,
 .form textarea:focus {
-  outline: 2px solid var(--color-text-link);
+  outline: 2px solid var(--spectrum-blue-900);
   outline-offset: 2px;
 }
 
@@ -161,11 +161,11 @@
 }
 
 .form .toggle-wrapper input:checked + .slider {
-  background-color: var(--color-text-link);
+  background-color: var(--spectrum-blue-900);
 }
 
 .form .toggle-wrapper input:focus + .slider {
-  outline: 2px solid var(--color-text-link);
+  outline: 2px solid var(--spectrum-blue-900);
   outline-offset: 2px;
 }
 

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -131,7 +131,6 @@ a.nav__home-link {
     display: block;
     padding-block: 2rem;
     padding-inline: var(--page-gutters);
-    font-size: var(--spectrum-font-size-200);
 
     &:hover {
       color: var(--spectrum-gray-900);
@@ -175,6 +174,7 @@ a.nav__home-link {
   .nav.nav--large-screens & {
     flex-direction: row;
     gap: 2rem;
+    font-size: var(--spectrum-font-size-200);
 
     & a.nav-page-links__link {
       padding: 0;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -131,6 +131,7 @@ a.nav__home-link {
     display: block;
     padding-block: 2rem;
     padding-inline: var(--page-gutters);
+    font-size: var(--spectrum-font-size-200);
 
     &:hover {
       color: var(--spectrum-gray-900);
@@ -205,7 +206,7 @@ a.nav__home-link {
 
     .theme-toggle__label {
       /* keep the font size aligned with the page links */
-      font-size: var(--body-size-xs);
+      font-size: var(--spectrum-font-size-200);
     }
   }
 }

--- a/blocks/link-list/link-list.css
+++ b/blocks/link-list/link-list.css
@@ -78,7 +78,12 @@
   display: flex;
   align-items: center;
   padding: 1rem 0;
-  text-decoration: none;
+  text-decoration-line: none;
+
+  &:hover,
+  &:focus-visible {
+    text-decoration: underline var(--link-underline-thickness); 
+  }
 
   &::after {
     --icon-size: 0.875rem;

--- a/blocks/page-header/page-header.css
+++ b/blocks/page-header/page-header.css
@@ -35,9 +35,11 @@
 
     & > a {
       color: var(--color-text);
+      text-decoration-line: none;
 
+      &:hover,
       &:focus-visible {
-        text-decoration: underline;
+        text-decoration-line: underline;
       }
     }
 

--- a/blocks/search-results/search-results.css
+++ b/blocks/search-results/search-results.css
@@ -55,6 +55,7 @@
         flex-direction: column;
         justify-content: space-between;
         color: var(--color-text);
+        text-decoration: none;
 
         @media (min-width: 42rem) {
             min-height: 100%;
@@ -62,6 +63,10 @@
 
         @media (min-width: 60rem) {
             flex-direction: row;
+        }
+
+        &:hover {
+            text-decoration: underline;
         }
     }
 

--- a/styles/base.css
+++ b/styles/base.css
@@ -387,10 +387,11 @@
     --spectrum-overlay-opacity: 0.6;
   }
 
-  /* ** BORDER ** */
+  /* ** BORDER AND UNDERLINE ** */
   --spectrum-border-width-100: 1px;
   --spectrum-border-width-200: 2px;
   --spectrum-border-width-400: 4px;
+  --link-underline-thickness: 0.0625em;
 
   /* ** CORNER ROUNDING ** */
   --spectrum-corner-radius-0: 0px;

--- a/styles/global-blocks.css
+++ b/styles/global-blocks.css
@@ -447,15 +447,6 @@
         margin-block-end: 0;
       }
     }
-
-    & a {
-      color: currentColor;
-      text-decoration: underline;
-
-      &:hover {
-        text-decoration: none;
-      }
-    }
   }
 }
 
@@ -863,6 +854,7 @@ body.color-scheme-dark .search .search__results-container {
 a.card {
   /* Ensure base focus styles are overridden. */
   border-radius: 1rem;
+  text-decoration: none;
 }
 
 a.card:hover {
@@ -968,11 +960,16 @@ a.card:hover {
   flex-direction: column;
   padding: 1rem 0;
   position: relative;
-  text-decoration: none;
+  text-decoration-line: none;
   color: var(--color-text-dark);
 
   &:any-link {
     color: var(--color-text-dark);
+
+    &:hover,
+    &:focus-visible {
+      text-decoration-line: underline;
+    }
   }
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -502,14 +502,23 @@ button {
 }
 
 a {
-  color: var(--color-text-link);
-  text-decoration: none;
+  color: currentcolor;
   overflow-wrap: break-word;
+  text-decoration: underline var(--link-underline-thickness); 
+  text-underline-offset: var(--link-underline-thickness);
+}
+
+u {
+  text-decoration: underline var(--link-underline-thickness); 
+  text-underline-offset: var(--link-underline-thickness);
+}
+
+:where(a) u {
+  text-decoration: none;
 }
 
 a:hover {
-  color: var(--color-text-link-hover);
-  text-decoration: underline;
+  color: currentcolor;
 }
 
 :where(ol, ul, p) {


### PR DESCRIPTION
## Summary of changes

### feat: change default links to secondary underlined
    
Per design request, changes the anchor link default to be the "[secondary](https://react-spectrum.adobe.com/Link)" variant underlined link using the current color. For hover and focus, the underline stays and the color does not change. Adjusts site wide component links to maintain their existing underlined and non-underlined states.

### fix: correct nav link font size

The large screen nav link size was too small at its in-between breakpoint (small desktop and large desktop) due to previous changes in the `--body-size-xs` CSS variable used by the font utility class being applied.

## Relevant Links
- Story: [ADB-321](https://sparkbox.atlassian.net/browse/ADB-321)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://feat-default-link-styles--adobe-design-website--adobe.aem.page/

## Checklist
* [x] This PR has code changes, and our linters still pass.
* [x] This PR affects production code, so it was browser tested (see below).

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. Test all pages on the site and multiple articles. See updated link style on links used in articles. Existing links, cards, career links, buttons, etc including their hover should not be changed (no unexpected underlines on other elements).
4. Recommended to also test and look at elements in `/pattern-library/`

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [x] Chrome
* [x] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
