### PR TITLE
feat: article header title size and spacing

### DIFF
--- a/blocks/article-header/article-header.css
+++ b/blocks/article-header/article-header.css
@@ -91,7 +91,7 @@
   max-width: 66rem;
   margin-inline: auto;
   margin-block-end: 2rem;
-  row-gap: 1.25rem;
+  row-gap: 1.0rem;
 
   @media (min-width: 36rem) {
     row-gap: 1.5rem;
@@ -119,10 +119,10 @@
 }
 
 .article-header__headline-group {
-  row-gap: 1.0rem;
+  row-gap: 0.25rem;
 
-  @media (min-width: 80rem) {
-    row-gap: 1.25rem;
+  @media (min-width: 48rem) {
+    row-gap: 0.5rem;
   }
 }
 
@@ -140,19 +140,25 @@
 
 .article-header__title {
   font-family: var(--heading-font-family);
-  font-size: var(--spectrum-font-size-600);
+  font-size: var(--spectrum-font-size-800);
   font-weight: var(--spectrum-black-font-weight);
   line-height: 1.15;
 
-  @media (min-width: 36rem) {
-    font-size: var(--spectrum-font-size-800);
+  @media (min-width: 23.438rem) {
+    font-size: var(--spectrum-font-size-1000);
     line-height: 1.12;
   }
-  @media (min-width: 80rem) {
+
+  @media (min-width: 36rem) {
     font-size: var(--spectrum-font-size-1100);
   }
+
+  @media (min-width: 64rem) {
+    font-size: 3.75rem;
+  }
+
   @media (min-width: 105rem) {
-    font-size: var(--spectrum-font-size-1200);
+    font-size: 5.625rem;
   }
 }
 
@@ -178,11 +184,7 @@
   font-size: var(--spectrum-font-size-100);
   font-weight: var(--spectrum-medium-font-weight);
   line-height: 1.25;
-  margin-block-end: 0.25rem;
-
-  @media (min-width: 80rem) {
-    margin-block-end: 0.5rem;
-  }
+  margin-block-end: 0.125rem;
 }
 
 .article-header__author {


### PR DESCRIPTION
## Summary of changes

**Article header title size and spacing**
Designed adjustments to font size and spacing in the article header.

## Relevant Links
- Designs: [Figma](https://www.figma.com/design/QzvOszpLGT7fwSd6N7gaDW/Adobe-Design?node-id=5299-8825&m=dev)
- Story: [ADB-328](https://sparkbox.atlassian.net/browse/ADB-328)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://feat-title-iteration--adobe-design-website--adobe.aem.page/

## Checklist
* [x] This PR has code changes, and our linters still pass.
* [x] This PR affects production code, so it was browser tested (see below).

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. Article title font size is 40px at 475px width, 60px at 1024px width, and 90px at 1680 width. Row gap between title goes from 4px to 8px responsively. Row gap between "Word by" and name is 2px.

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [x] Chrome
* [ ] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
