### PR TITLE
fix: github workflow puppeteer chrome install

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          # Use 24.15 as a workaround for Puppeteer Chrome install issue 14957, until fully upgrading to Puppeteer 25+.
+          node-version: 24.15
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
## Summary of changes

### Fix Puppeteer Chrome install
    
The Github workflow "Run Jest Puppeteer Tests" began failing for all PRs with an error about "Could not find Chrome":
```
Could not find Chrome (ver. 138.0.7204.94). This can occur if either
     1. you did not perform an installation before running the script (e.g. `npx puppeteer browsers install chrome`) or
     2. your cache path is incorrectly configured (which is: /home/runner/.cache/puppeteer).
    For (2), check out our guide on configuring puppeteer at https://pptr.dev/guides/configuration.
```

The issue ended up being a Puppeteer issue (number 14957) related to a dependency and newer versions of node. This workaround sets the node version to 24.15 so the tests can continue to run (breaks on node 24.16). Later we can upgrade to Puppeteer 25+ which fixes the issue (I attempted that first but it isn't a simple upgrade with all the module syntax changes + how that connects with Jest).

## Relevant Links
- Story: [ADB-329](https://sparkbox.atlassian.net/browse/ADB-329)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-puppeteer-tests--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR has new code, so new tests were added or updated, and they pass.

## Validation
1. Confirm "Run Jest Puppeteer Tests" workflow is not failing on this PR.

---