### PR TITLE
fix: match section header ghost button to updated secondary link style

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -126,11 +126,11 @@ main picture:not([class]) > img:not([class]) {
   font-weight: var(--spectrum-bold-font-weight);
   line-height: 1.3;
   text-align: center;
-  text-decoration: none;
+  text-decoration-line: none;
   cursor: pointer;
 
   &:hover {
-    text-decoration: none;
+    text-decoration-line: none;
   }
 
   &:disabled,
@@ -349,17 +349,18 @@ body.color-scheme-dark .button--accent {
 }
 
 .button--ghost {
-  --color-button-text-ghost: var(--color-text-link);
-  --color-button-text-ghost-hover: var(--color-text-link-hover);
+  --color-button-text-ghost: currentcolor;
+  --color-button-text-ghost-hover: currentcolor;
 
   color: var(--color-button-text-ghost);
   font-size: var(--spectrum-font-size-200);
   font-weight: var(--spectrum-medium-font-weight);
+  text-decoration-line: underline;
 
   &:hover,
   &:focus-visible {
     color: var(--color-button-text-ghost-hover);
-    text-decoration: underline;
+    text-decoration-line: underline;
   }
 }
 


### PR DESCRIPTION
## Summary of changes

**fix: match section header ghost button to updated secondary link style**
Bring the changes in ADB-317 and ADB-321 into alignment, for the ghost button used on the homepage "View all". It now uses the secondary link style intended for all text links.

<img width="297" height="215" alt="Screenshot 2026-06-12 at 11 53 19 AM" src="https://github.com/user-attachments/assets/b622c29b-0ba1-4064-8858-97c6c750e681" />

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://fix-ghost-button-style--adobe-design-website--adobe.aem.page/

## Checklist
* [x] This PR has code changes, and our linters still pass.
* [x] This PR affects production code, so it was browser tested (see below).

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. Confirm underlined by default secondary link styles used on homepage "View all".

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [x] Chrome
* [x] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
