### PR TITLE
feat: use regular card styles for search results page

### DIFF
--- a/blocks/card/card.js
+++ b/blocks/card/card.js
@@ -26,13 +26,15 @@ export function buildCard(cardData, cardContainerElement = 'div') {
   }
 
   // Append image.
-  if (cardData?.img && cardData.img) {
+  if (cardData?.img) {
+    let picture = cardData.img;
+
     // Create picture element, if arg is the image URL.
-    let picture = null;
     if (typeof cardData.img === 'string') {
       picture = createOptimizedPicture(cardData.img);
     }
 
+    // Modify picture element and append it.
     if (picture instanceof HTMLPictureElement) {
       picture.classList.add('card__image');
       // Set empty alt, to treat images within the card as decorative.

--- a/blocks/card/card.js
+++ b/blocks/card/card.js
@@ -1,9 +1,10 @@
 import { appendCleanText } from '../../scripts/helpers/index.js';
+import { createOptimizedPicture } from '../../scripts/aem.js';
 
 /**
  * Represents the data used within a card.
  * @typedef {object} CardData
- * @property {HTMLPictureElement} img - Card image(s) within a picture element.
+ * @property {HTMLPictureElement|string} img - Card image(s) within a picture element, or URL of image that will be converted into one.
  * @property {HTMLCollection} textContent - Iterable elements containing one paragraph for the title and one for the description.
  * @property {string} url - URL that the card links to.
  */
@@ -11,10 +12,11 @@ import { appendCleanText } from '../../scripts/helpers/index.js';
 /**
  * Create markup for a single card from card data, and return it.
  * @param {CardData} cardData
- * @returns {HTMLDivElement}
+ * @param {string} cardContainerElement Type of element to use to wrapping container (e.g. 'div' or 'li').
+ * @returns {HTMLDivElement} The markup for the card.
  */
-export function buildCard(cardData) {
-  const cardContainer = document.createElement('div');
+export function buildCard(cardData, cardContainerElement = 'div') {
+  const cardContainer = document.createElement(cardContainerElement);
   cardContainer.className = 'card-container';
 
   const card = cardData?.url ? document.createElement('a') : document.createElement('div');
@@ -23,19 +25,30 @@ export function buildCard(cardData) {
     card.setAttribute('href', cardData.url);
   }
 
-  if (cardData?.img) {
-    cardData.img.classList.add('card__image');
-    cardData.img.setAttribute('alt', '');
-    card.append(cardData.img);
+  // Append image.
+  if (cardData?.img && cardData.img) {
+    // Create picture element, if arg is the image URL.
+    let picture = null;
+    if (typeof cardData.img === 'string') {
+      picture = createOptimizedPicture(cardData.img);
+    }
+
+    if (picture instanceof HTMLPictureElement) {
+      picture.classList.add('card__image');
+      // Set empty alt, to treat images within the card as decorative.
+      picture.querySelectorAll('img').forEach((img) => img.setAttribute('alt', ''));
+      card.append(picture);
+    }
   }
 
+  // Append title and description.
   const cardContent = document.createElement('div');
   cardContent.classList.add('card__content');
   appendCleanText(cardData.textContent, cardContent);
   cardContent.children?.[0]?.classList.add('card__title', 'util-title-s');
   cardContent.children?.[1]?.classList.add('card__description','util-body-s');
-
   card.append(cardContent);
+
   cardContainer.append(card);
   return cardContainer;
 }
@@ -50,7 +63,7 @@ export default function decorate(block) {
     textContent: block.children[1].children[0].children,
     url: block.children[2].textContent.trim()
   };
-  const cardContainer = buildCard(cardData);
+  const cardContainer = buildCard(cardData, 'div');
 
   // Replaces empty wrapper div with new markup.
   block.parentElement.replaceWith(cardContainer);

--- a/blocks/search-results/search-results.css
+++ b/blocks/search-results/search-results.css
@@ -27,101 +27,13 @@
 .search-results__list {
     box-sizing: border-box;
     list-style: none;
-    display: grid;
-    grid-template-columns: minmax(0, 1fr);
-    gap: 2rem;
     margin: 1.5rem 0;
     padding: 0;
-
-    @media (min-width: 42rem) {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
-    @media (min-width: 85rem) {
-       grid-template-columns: repeat(3, minmax(0, 1fr));
-    }
-}
-
-.search-results__item {
-    box-sizing: border-box;
-    display: block;
-    margin: 0;
-    border-radius: var(--spectrum-corner-radius-400);
-    background: var(--spectrum-white);
-    box-shadow: var(--drop-shadow-emphasized);
-
-    & a {
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-        color: var(--color-text);
-        text-decoration: none;
-
-        @media (min-width: 42rem) {
-            min-height: 100%;
-        }
-
-        @media (min-width: 60rem) {
-            flex-direction: row;
-        }
-
-        &:hover {
-            text-decoration: underline;
-        }
-    }
-
-    & :where(p) {
-        margin-block: 0.25rem 0;
-    }
-
-    & span {
-        display: block;
-    }
-}
-
-body.color-scheme-dark .search-results__item {
-    background: var(--spectrum-gray-50);
-}
-
-.search-results__content {
-    padding: 1.25rem;
-
-    @media (min-width: 60rem) {
-        padding: 1.5rem;
-    }
-}
-
-.search-results__visual {
-    margin: 0;
-    padding: 0;
-    overflow: hidden;
-    aspect-ratio: 3.25;
-    max-height: 10rem;
-    border-radius: 0 0 var(--spectrum-corner-radius-400) var(--spectrum-corner-radius-400);
-    border-top: 1px solid var(--spectrum-gray-75);
-    background: var(--spectrum-gray-75);
-
-    @media (min-width: 60rem) {
-        height: auto;
-        max-height: none;
-        aspect-ratio: auto;
-        flex: 0 0 19.5%;
-        min-width: 5.5rem;
-        border-radius: 0 var(--spectrum-corner-radius-400) var(--spectrum-corner-radius-400) 0;
-        border-left: 1px solid var(--spectrum-gray-75);
-        border-top: none;
-    }
-
-    & img {
-        display: block;
-        object-fit: cover;
-        height: 100%;
-        width: 100%;
-    }
 }
 
 .search-results__badge {
-    display: inline-block;
+    align-self: flex-start;
+    order: -1;
     vertical-align: top;
     font-size: 0.75rem;
     background: var(--spectrum-blue-200);
@@ -133,14 +45,6 @@ body.color-scheme-dark .search-results__item {
     @media (min-width: 105rem) {
        margin-block-end: 1.5rem;
     }
-}
-
-.search-results__title {
-    margin-block-end: 0.25rem;
-}
-
-.search-results__department {
-    font-weight: var(--spectrum-medium-font-weight);
 }
 
 /* "Go back home" link at top in content. */

--- a/blocks/search-results/search-results.css
+++ b/blocks/search-results/search-results.css
@@ -33,7 +33,6 @@
 
 .search-results__badge {
     align-self: flex-start;
-    order: -1;
     vertical-align: top;
     font-size: 0.75rem;
     background: var(--spectrum-blue-200);
@@ -41,6 +40,10 @@
     border-radius: var(--spectrum-corner-radius-400);
     padding: 0.25rem 0.625rem;
     margin-block: 0 1.0rem;
+
+    & span {
+        display: initial;
+    }
 
     @media (min-width: 105rem) {
        margin-block-end: 1.5rem;

--- a/blocks/search-results/search-results.js
+++ b/blocks/search-results/search-results.js
@@ -47,7 +47,14 @@ const buildResultsGrid = (results) => {
       const badge = document.createElement('p');
       badge.classList.add('search-results__badge');
       badge.textContent = publicationDate.toLocaleDateString('en-US', { timeZone: 'UTC', month: 'short', day: 'numeric', year: 'numeric' });
-      cardContent.append(badge);
+
+      // Have screen readers pause after reading the date.
+      const srOnlyPause = document.createElement('span');
+      srOnlyPause.classList.add('util-visually-hidden');
+      srOnlyPause.textContent = ".";
+      badge.append(srOnlyPause);
+
+      cardContent.prepend(badge);
     }
 
     // Append card to parent list.

--- a/blocks/search-results/search-results.js
+++ b/blocks/search-results/search-results.js
@@ -1,6 +1,7 @@
 import { dataStore } from "../../scripts/helpers/index.js";
 import { filterData, getSearchTermsArray, sectionNameFromPath } from "../search/search.js";
 import { loadFragment } from '../fragment/fragment.js';
+import { buildCard } from "../card/card.js";
 
 /* Path to page containing the content displayed when there are no results. */
 const noSearchResultsPartial = '/partials/no-search-results';
@@ -9,80 +10,48 @@ const noSearchResultsPartial = '/partials/no-search-results';
  * Build grid of search results from returned data.
  * 
  * @param {object} results Results of search.
- * @param {string} titleHeadingLevel Which element to create for the results item title.
  * @returns {HTMLUListElement}
  */
-const buildresultsGrid = (results, titleHeadingLevel = 'h2') => {
+const buildResultsGrid = (results) => {
+  // Parent list of all results.
   const resultsList = document.createElement('ul');
-  resultsList.classList.add('search-results__list');
+  resultsList.classList.add('search-results__list', 'grid-container');
 
+  // Build and append a card for each result.
   results.forEach((result) => {
     const sectionName = sectionNameFromPath(result.path, result?.author);
     const hasImage = sectionName == "Article" && result?.image;
 
-    const listItem = document.createElement('li');
-    listItem.classList.add('search-results__item');
+    // Create base card markup.
+    const card = buildCard(
+      {
+        img: hasImage ? (result?.image?.trim() ?? '') : '',
+        textContent: [
+            result?.title ?? '',
+            result?.description ?? ''
+        ],
+        url: result.path,
+      },
+      'li'
+    );
 
-    const anchor = document.createElement('a');
-    anchor.href = result.path;
-    listItem.append(anchor);
+    // Adjust card markup.
+    card.classList.add('grid-item', 'grid-item--25', 'search-results__item');
 
-    const contentWrap = document.createElement('div');
-    contentWrap.classList.add('search-results__content');
-    anchor.append(contentWrap);
-
-    // Badge with publication date.
+    // Append Badge with publication date.
     if (result?.publicationDate) {
+      const cardContent = card.querySelector('.card__content');
+      if (!cardContent) return;
       // Convert Excel serial date (e.g. "45981") to Date object that can be displayed.
       const publicationDate = new Date(Date.UTC(0, 0, parseInt(result.publicationDate) - 1));
       const badge = document.createElement('p');
       badge.classList.add('search-results__badge');
       badge.textContent = publicationDate.toLocaleDateString('en-US', { timeZone: 'UTC', month: 'short', day: 'numeric', year: 'numeric' });
-      contentWrap.append(badge);
+      cardContent.append(badge);
     }
 
-    // Result title.
-    const title = document.createElement(titleHeadingLevel);
-    title.classList.add('util-title-xl','search-results__title');
-    title.textContent = result.title;
-    contentWrap.append(title);
-
-    // Page description or job listing department and location.
-    if (sectionName == "Job Listing") {
-      if (result?.department) {
-        const desc = document.createElement('p');
-        desc.classList.add('util-body-s', 'search-results__department');
-        desc.textContent = result.department;
-        contentWrap.append(desc);
-      }
-      if (result?.location) {
-        const desc = document.createElement('p');
-        desc.classList.add('util-body-xs');
-        desc.textContent = result.location;
-        contentWrap.append(desc);
-      }
-    } else {
-      if (result?.description) {
-        const desc = document.createElement('p');
-        desc.classList.add('util-body-s');
-        desc.textContent = result.description;
-        contentWrap.append(desc);
-      }
-    }
-
-    // Image for articles.
-    if (hasImage) {
-      const imageWrap = document.createElement('figure');
-      imageWrap.classList.add('search-results__visual');
-      const image = document.createElement('img');
-      image.src = result.image;
-      image.alt = "";
-      image.loading = "lazy";
-      imageWrap.append(image);
-      anchor.append(imageWrap);
-    }
-
-    resultsList.append(listItem);
+    // Append card to parent list.
+    resultsList.append(card);
   });
 
   return resultsList;
@@ -120,7 +89,7 @@ export default function decorate(block) {
   const searchTerms = getSearchTermsArray(searchValue);
   
   (async () => {
-    // Query all data and search it.
+    // Query all data and search it. Only search articles.
     const allFetchedData = await dataStore.getData(dataStore.commonEndpoints.ideas);
     const results = filterData(searchTerms, allFetchedData?.data);
     const hasResults = results && results.length > 0;
@@ -152,7 +121,7 @@ export default function decorate(block) {
     blockContainer.append(resultsTotal);
 
     // Build search results grid.
-    const resultsGrid = buildresultsGrid(results, 'h2');
+    const resultsGrid = buildResultsGrid(results, 'h2');
     blockContainer.append(resultsGrid);
   })();
 }

--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -384,7 +384,7 @@ export default async function decorate(block) {
   // Placeholder strings; not currently in use.
   const placeholders = {};
 
-  // Endpoint for search data.
+  // Endpoint for search data. Only search articles.
   const source = dataStore.commonEndpoints.ideas;
   
   // Build block markup.

--- a/scripts/helpers/fetchAndBuildIdeas.js
+++ b/scripts/helpers/fetchAndBuildIdeas.js
@@ -1,4 +1,3 @@
-import { createOptimizedPicture } from "../aem.js";
 import { buildCard } from "../../blocks/card/card.js";
 import { dataStore } from "./dataStore.js";
 
@@ -69,14 +68,17 @@ export const fetchAndBuildIdeas = async (settings) => {
         filteredArticles.forEach((article, idx) => {
             // Create card and append.
             const articleImageUrl = article.image.trim();
-            const card = buildCard({
-                img: articleImageUrl ? createOptimizedPicture(articleImageUrl) : '',
-                textContent: [
-                    article.title,
-                    article.description
-                ],
-                url: article.path.trim(),
-            });
+            const card = buildCard(
+                {
+                    img: articleImageUrl ?? '',
+                    textContent: [
+                        article.title,
+                        article.description
+                    ],
+                    url: article.path.trim(),
+                },
+                'div'
+            );
             card.classList.add('grid-item', settings.gridItemClass);
 
             // If article is last available, mark it with a data attribute.

--- a/styles/global-blocks.css
+++ b/styles/global-blocks.css
@@ -834,6 +834,8 @@ body.color-scheme-dark .search .search__results-container {
 .card-container {
   container-type: inline-size;
   container-name: card-container;
+  margin: 0;
+  padding: 0;
 }
 
 .card {


### PR DESCRIPTION
## Summary of changes

### Use regular card styles for search results page

Changes the search results to use the regular card styles/markup, as it is used on other pages. Includes the added badge with the date. Removes most of its custom card styling and markup.

Adds an option to `buildCard` to pass in the image URL instead of the picture element, and refactors where `createOptimizedPicture` is used so it runs within this function instead of having to be imported and called elsewhere.

Adds a parameter so `buildCard` can be created with an `li` container instead of a `div`.

<img width="1494" height="706" alt="Screenshot 2026-06-12 at 2 51 33 PM" src="https://github.com/user-attachments/assets/a9ec0c75-e18e-4313-ae6f-1cc62ca8fc60" />

## Relevant Links
- Story: [ADB-315](https://sparkbox.atlassian.net/browse/ADB-315)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://feat-search-cards--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] :star: This PR has visual changes, and the PR testing link has been reviewed by a designer. **NOTE: share testing link for approval before merge.**
* [x] This PR has code changes, and our linters still pass.
* [x] This PR affects production code, so it was browser tested (see below).

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. The search results page shows cards with the same styles as the homepage and Ideas page article list. Cards look correct and are responsive in the same way.
4. No regressions on the existing post lists on the homepage, tag pages, and ideas page.
5. Voiceover reads visually hidden punctuation that gives a pause between the date and the title.

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [x] Firefox
* [x] Chrome
* [x] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
