### PR TITLE
feat: recent ideas block - choose specific slugs

### DIFF
--- a/blocks/recent-ideas/recent-ideas.js
+++ b/blocks/recent-ideas/recent-ideas.js
@@ -8,6 +8,7 @@ import { fetchAndBuildIdeas } from "../../scripts/helpers/index.js";
  * - Pulls in articles by the tag entered, or all articles.
  * - Limits articles to the max number entered, or can display all.
  * - Can display articles in a "two-up" or "four-up" layout.
+ * - Has extra options for displaying related articles or specific articles by their slugs.
  */
 export default function decorate(block) {
     // Block settings from content.
@@ -17,12 +18,26 @@ export default function decorate(block) {
         gridItemClass: block.children?.[2]?.children?.[0]?.textContent?.trim().toLowerCase() === "two-up" ? 'grid-item--50' : 'grid-item--25',
         hasHorizontalScroll: block.children?.[2]?.children?.[1]?.textContent?.trim().toLowerCase() === "scrolling",
     };
-
-    // Special case tag name; get tags from page metadata or fall back to "All". 
-    // Used for finding related stories to an article.
+    
+    // Adjustments for optional special case settings.
     if (settings.tagName?.[0]?.trim() === "UseMetadataTags") {
+        // Special case tag name; get tags from page metadata or fall back to "All". 
+        // Used for finding related stories to an article.
         const metadataTags = getMetadata("tag");
         settings.tagName = metadataTags ? metadataTags.split(",") : ["All"];
+    } else if (settings.tagName?.[0]?.trim().startsWith("ArticlesBySlug:")) {
+        // Special case tag name; get a specific list of posts by their slug.
+        // Allows displaying a curated list of posts that don't have a common tag.
+        let articleSlugs = settings.tagName.map(
+            // Remove all line breaks, tabs, and prefix text. And get the slug without slashes.
+            s => s.replace(/[\n\r\t]/g, "").replace("ArticlesBySlug:", "").replace("/ideas/", "").trim().replace(/^\/|\/$/g, "")
+        );
+        // Add setting and adjust other settings.
+        if (articleSlugs?.[0]) {
+            settings.articleSlugs = articleSlugs;
+            settings.tagName = ["All"];
+            settings.maxArticles = -1;
+        }
     }
 
     // Create a new container to house the block.

--- a/scripts/helpers/fetchAndBuildIdeas.js
+++ b/scripts/helpers/fetchAndBuildIdeas.js
@@ -10,6 +10,7 @@ import { dataStore } from "./dataStore.js";
  * @property {string} gridItemClass - Class for each grid item that determines layout; e.g. "grid-item--25" for four-up layout.
  * @property {boolean} hasHorizontalScroll - Has horizontal scroll at mobile.
  * @property {string|null} startAfterPath - Optional; return results older than ideas article matching this path.
+ * @property {string[]} articleSlugs - Optional; fetch specific articles by their slugs.
  */
 
 /**
@@ -44,13 +45,20 @@ export const fetchAndBuildIdeas = async (settings) => {
             );
         }
 
+        // Filter by slug(s) if this option was used to display specific articles.
+        if (settings?.articleSlugs && settings.articleSlugs.length > 0) {
+            filteredArticles = filteredArticles.filter(item =>
+                settings.articleSlugs.some(slug => item?.path?.endsWith(slug) ?? false)
+            );
+        }
+
         // Exclude the current path, so we don't show the same article on an article page.
         filteredArticles = filteredArticles.filter(item => item?.path !== window.location.pathname);
 
         // Sort by published date (serial number or timestamp), with the latest dates first.
         filteredArticles = filteredArticles.sort((a, b) => parseInt(b.publishedDate, 10) - parseInt(a.publishedDate, 10));
 
-        // Need to return next set of results starting from article with this path?
+        // Pagination/load more; setting for returning the next set of results starting from the article with this path.
         let startFromIndex = 0;
         if (settings?.startAfterPath) {
             const foundIndex = filteredArticles.findIndex(article => article?.path.trim() === settings.startAfterPath);


### PR DESCRIPTION
## Summary of changes

Adds an option to display specific articles in the recent ideas block by using a list of comma separated article slugs. 
This requires the use of "ArticlesBySlug:" in the tag content column. Here is an example:
`ArticlesBySlug: article-slug1, article-slug2`

Any slugs that don't exist will be ignored and not displayed.

Includes an example and documentation in the Pattern Library.

## Relevant Links
- Story: [ADB-314](https://sparkbox.atlassian.net/browse/ADB-314)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://feat-posts-by-slug--adobe-design-website--adobe.aem.page/

## Checklist
* [x] This PR has code changes, and our linters still pass.
* [x] In pattern library: The content of this PR requires documentation, so we added a detailed description of the component's purpose, requirements, quirks, and instructions for use by designers and developers. This includes accessibility information if pertinent.

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. Confirm working example in pattern library displays the specific slugs. The example shows that it works whether or not slashes, line breaks, or spaces are included in the comma separated content. And that a non existing article does not appear or cause errors.
4. Confirm no errors or change in posts displayed in the existing post lists on various pages (home, ideas, tag, pattern library, recent articles at the bottom of articles).

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [x] Chrome
* [ ] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
