### PR TITLE
feat: quote redesign

### DIFF
--- a/blocks/quote/quote.css
+++ b/blocks/quote/quote.css
@@ -3,26 +3,31 @@
   --color-border: var(--spectrum-gray-400);
 
   position: relative;
-  margin: 2.0rem auto;
-  padding-block: 2.0rem;
+  margin: 1.5rem auto;
+  padding: 1.0rem;
   font-family: var(--spectrum-serif-font);
-  line-height: 1.4;
+  line-height: 1.5;
   letter-spacing: 0;
   color: var(--color-text);
-  border-block: 1px solid var(--color-border);
 
   @media (min-width: 48rem) {
-    margin-block: 2.5rem;
+    padding-inline: 2.0rem;
   }
 
   @media (min-width: 80rem) {
-    padding-block: 3.0rem;
-    margin-block: 4.0rem;
+    margin-block: 3.0rem;
+    padding-inline: 3.0rem;
   }
 }
 
 .quote__quotation {
   margin: 0;
+  line-height: 1.5;
+  font-style: italic;
+
+  @media (min-width: 105rem) {
+    font-size: var(--spectrum-font-size-750);
+  }
 
   & + .quote__quotation {
     margin-top: 0.5em;

--- a/blocks/quote/quote.css
+++ b/blocks/quote/quote.css
@@ -1,6 +1,5 @@
 .quote blockquote {
   --color-text: var(--themed-text-color, var(--spectrum-gray-700));
-  --color-border: var(--spectrum-gray-400);
 
   position: relative;
   margin: 1.5rem auto;

--- a/blocks/quote/quote.css
+++ b/blocks/quote/quote.css
@@ -1,6 +1,7 @@
 .quote blockquote {
-  --color-text: var(--spectrum-gray-700);
+  --color-text: var(--themed-text-color, var(--spectrum-gray-700));
   --color-border: var(--spectrum-gray-400);
+
   position: relative;
   margin: 2.0rem auto;
   padding-block: 2.0rem;

--- a/styles/base.css
+++ b/styles/base.css
@@ -78,6 +78,7 @@
   --spectrum-blue-800: rgb(75 117 255);
   --spectrum-blue-900: rgb(59 99 251);
   --spectrum-blue-1000: rgb(39 77 234);
+  --spectrum-blue-1200: rgb(21 50 173);
   --spectrum-blue-1400: rgb(12 31 105);
 
   --spectrum-gray-25: rgb(255 255 255);
@@ -98,10 +99,12 @@
   --spectrum-indigo-400: rgb(192 201 255);
   --spectrum-indigo-500: rgb(167 178 255);
   --spectrum-indigo-1000: rgb(99 56 238);
+  --spectrum-indigo-1200: rgb(69 19 191);
 
   --spectrum-cyan-400: rgb(138 213 255);
   --spectrum-cyan-500: rgb(92 192 255);
   --spectrum-cyan-600: rgb(48 167 254);
+  --spectrum-cyan-1200: rgb(0 71 98);
   --spectrum-cyan-1400: rgb(0 43 59);
 
   --spectrum-green-300: rgb(173 238 197);
@@ -111,15 +114,18 @@
 
   --spectrum-fuchsia-400: rgb(247 181 255);
   --spectrum-fuchsia-500: rgb(243 147 255);
+  --spectrum-fuchsia-1200: rgb(113 15 131);
   --spectrum-fuchsia-1400: rgb(72 0 88);
 
   --spectrum-orange-400: rgb(255 193 94);
   --spectrum-orange-800: rgb(199 82 0);
+  --spectrum-orange-1200: rgb(118 41 0);
   --spectrum-orange-1400: rgb(73 24 0);
 
   --spectrum-seafoam-300: rgb(169 237 216);
   --spectrum-seafoam-400: rgb(92 225 194);
   --spectrum-seafoam-600: rgb(13 181 149);
+  --spectrum-seafoam-1200: rgb(1 75 67);
   --spectrum-seafoam-1400: rgb(0 46 40);
 
   --spectrum-turquoise-200: rgb(209 245 245);
@@ -129,10 +135,12 @@
   --spectrum-red-500: rgb(255 157 145);
   --spectrum-red-600: rgb(255 118 101);
   --spectrum-red-700: rgb(255 81 61);
+  --spectrum-red-1200: rgb(129 27 14);
   --spectrum-red-1400: rgb(80 16 6);
 
   --spectrum-brown-1400: rgb(52 37 13);
   --spectrum-cinnamon-500: rgb(229 170 136);
+  --spectrum-cinnamon-1200: rgb(110 48 21);
 
   &:has(body.color-scheme-dark) {
     --spectrum-blue-200: rgb(15 28 82);
@@ -143,6 +151,7 @@
     --spectrum-blue-800: rgb(64 105 253);
     --spectrum-blue-900: rgb(86 129 255);
     --spectrum-blue-1000: rgb(105 149 254);
+    --spectrum-blue-1200: rgb(152 192 252);
     --spectrum-blue-1400: rgb(213 231 254);
 
     --spectrum-gray-25: rgb(17 17 17);
@@ -163,10 +172,12 @@
     --spectrum-indigo-400: rgb(62 12 174);
     --spectrum-indigo-500: rgb(79 30 209);
     --spectrum-indigo-1000: rgb(139 141 254);
+    --spectrum-indigo-1200: rgb(176 186 255);
 
     --spectrum-cyan-400: rgb(0 64 88);
     --spectrum-cyan-500: rgb(0 82 113);
     --spectrum-cyan-600: rgb(3 99 140);
+    --spectrum-cyan-1200: rgb(107 199 255);
     --spectrum-cyan-1400: rgb(195 236 252);
 
     --spectrum-green-300: rgb(0 51 38);
@@ -176,15 +187,18 @@
 
     --spectrum-fuchsia-400: rgb(102 9 120);
     --spectrum-fuchsia-500: rgb(127 23 146);
+    --spectrum-fuchsia-1200: rgb(245 159 255);
     --spectrum-fuchsia-1400: rgb(251 219 255);
 
     --spectrum-orange-400: rgb(106 36 0);
     --spectrum-orange-800: rgb(212 91 0);
+    --spectrum-orange-1200: rgb(255 173 45);
     --spectrum-orange-1400: rgb(255 225 178);
 
     --spectrum-seafoam-300: rgb(0 50 44);
     --spectrum-seafoam-400: rgb(0 67 59);
     --spectrum-seafoam-600: rgb(4 105 89);
+    --spectrum-seafoam-1200: rgb(29 214 176);
     --spectrum-seafoam-1400: rgb(186 241 222);
 
     --spectrum-turquoise-200: rgb(0 37 41);
@@ -194,10 +208,12 @@
     --spectrum-red-500: rgb(147 31 17);
     --spectrum-red-600: rgb(177 38 23);
     --spectrum-red-700: rgb(205 46 29);
+    --spectrum-red-1200: rgb(255 167 157);
     --spectrum-red-1400: rgb(255 222 219);
 
     --spectrum-brown-1400: rgb(242 227 206);
     --spectrum-cinnamon-500: rgb(122 57 28);
+    --spectrum-cinnamon-1200: rgb(232 179 149);
   }
 
   /* functional colors */

--- a/styles/base.css
+++ b/styles/base.css
@@ -110,7 +110,6 @@
   --spectrum-green-300: rgb(173 238 197);
   --spectrum-green-400: rgb(107 227 162);
   --spectrum-green-600: rgb(18 184 103);
-  --spectrum-green-1200: rgb(57, 215, 134);
   --spectrum-green-1400: rgb(189 241 208);
 
   --spectrum-fuchsia-400: rgb(247 181 255);
@@ -184,7 +183,6 @@
     --spectrum-green-300: rgb(0 51 38);
     --spectrum-green-400: rgb(0 68 48);
     --spectrum-green-600: rgb(3 106 67);
-    --spectrum-green-1200: rgb(1, 76, 52);
     --spectrum-green-1400: rgb(0 46 34);
 
     --spectrum-fuchsia-400: rgb(102 9 120);

--- a/styles/base.css
+++ b/styles/base.css
@@ -246,7 +246,7 @@
   /* Unique theme backgrounds that are used in tandem with shapes. */
   --gradient-backdrop-green-start: var(--spectrum-green-300);
   --gradient-backdrop-seafoam-start: rgb(142 233 214);
-  --gradient-backdrop-seaform-end: rgb(233 246 245);
+  --gradient-backdrop-seafoam-end: rgb(233 246 245);
   --gradient-backdrop-blue-green-wave-start: rgb(142 210 253);
 
   /* Multi-colored gradients */
@@ -263,7 +263,7 @@
     --gradient-orange-start: var(--spectrum-orange-800);
 
     --gradient-backdrop-seafoam-start: rgb(3 55 50);
-    --gradient-backdrop-seaform-end: rgb(17 33 34);
+    --gradient-backdrop-seafoam-end: rgb(17 33 34);
     --gradient-backdrop-blue-green-wave-start: rgb(8 63 68);
   }
 

--- a/styles/base.css
+++ b/styles/base.css
@@ -110,7 +110,8 @@
   --spectrum-green-300: rgb(173 238 197);
   --spectrum-green-400: rgb(107 227 162);
   --spectrum-green-600: rgb(18 184 103);
-  --spectrum-green-1400: rgb(0 46 34);
+  --spectrum-green-1200: rgb(57, 215, 134);
+  --spectrum-green-1400: rgb(189 241 208);
 
   --spectrum-fuchsia-400: rgb(247 181 255);
   --spectrum-fuchsia-500: rgb(243 147 255);
@@ -183,7 +184,8 @@
     --spectrum-green-300: rgb(0 51 38);
     --spectrum-green-400: rgb(0 68 48);
     --spectrum-green-600: rgb(3 106 67);
-    --spectrum-green-1400: rgb(189 241 208);
+    --spectrum-green-1200: rgb(1, 76, 52);
+    --spectrum-green-1400: rgb(0 46 34);
 
     --spectrum-fuchsia-400: rgb(102 9 120);
     --spectrum-fuchsia-500: rgb(127 23 146);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1133,7 +1133,7 @@ main > .section.small-screen-cta-container > .grid-container:has(+ .call-to-acti
 }
 
 .theme--backdrop-green {
-  --themed-text-color: var(--spectrum-green-1200, currentcolor);
+  --themed-text-color: var(--spectrum-seafoam-1200, currentcolor);
 }
 
 .theme--backdrop-blue-circles {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1128,6 +1128,26 @@ main > .section.small-screen-cta-container > .grid-container:has(+ .call-to-acti
   }
 }
 
+.theme--backdrop-indigo {
+  --themed-text-color: var(--spectrum-indigo-1200, currentcolor);
+}
+
+.theme--backdrop-green {
+  --themed-text-color: var(--spectrum-green-1200, currentcolor);
+}
+
+.theme--backdrop-blue-circles {
+  --themed-text-color: var(--spectrum-blue-1200, currentcolor);
+}
+
+.theme--backdrop-seafoam {
+  --themed-text-color: var(--spectrum-seafoam-1200, currentcolor);
+}
+
+.theme--backdrop-blue-green-wave {
+  --themed-text-color: var(--spectrum-blue-1200, currentcolor);
+}
+
 /* Backdrop heights */
 .theme--backdrop-indigo,
 .theme--backdrop-green {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1061,34 +1061,42 @@ main > .section.small-screen-cta-container > .grid-container:has(+ .call-to-acti
 /* -- Simple color themes with only a gradient. -- */
 .theme--blue {
   --page-gradient-start-color: var(--gradient-blue-start);
+  --themed-text-color: var(--spectrum-blue-1200, currentcolor);
 }
 
 .theme--cyan {
   --page-gradient-start-color: var(--gradient-cyan-start);
+  --themed-text-color: var(--spectrum-cyan-1200, currentcolor);
 }
 
 .theme--indigo {
   --page-gradient-start-color: var(--gradient-indigo-start);
+  --themed-text-color: var(--spectrum-indigo-1200, currentcolor);
 }
 
 .theme--fuchsia {
   --page-gradient-start-color: var(--gradient-fuchsia-start);
+  --themed-text-color: var(--spectrum-fuchsia-1200, currentcolor);
 }
 
 .theme--red {
   --page-gradient-start-color: var(--gradient-red-start);
+  --themed-text-color: var(--spectrum-red-1200, currentcolor);
 }
 
 .theme--seafoam {
   --page-gradient-start-color: var(--gradient-seafoam-start);
+  --themed-text-color: var(--spectrum-seafoam-1200, currentcolor);
 }
 
 .theme--cinnamon {
   --page-gradient-start-color: var(--gradient-cinnamon-start);
+  --themed-text-color: var(--spectrum-cinnamon-1200, currentcolor);
 }
 
 .theme--orange {
   --page-gradient-start-color: var(--gradient-orange-start);
+  --themed-text-color: var(--spectrum-orange-1200, currentcolor);
 }
 
 .theme--no-color {


### PR DESCRIPTION
## Summary of changes

Updates design of quotes to use theme specific colored text, no borders, and adjusted padding and margin.

## Relevant Links
- Story: [ADB-331](https://sparkbox.atlassian.net/browse/ADB-331)

## Test URLs:
- Before: https://main--adobe-design-website--adobe.aem.page/
- After: https://feat-quote-redesign--adobe-design-website--adobe.aem.page/

## Checklist
* [ ] This PR has visual changes, and has been reviewed by a designer.
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR affects production code, so it was browser tested (see below).

## Validation
1. Make sure all PR checks have passed.
2. Pull down all related branches.
3. Go to an article page with at least one quote. You can then paste this script into the console to swap between color themes to test the text colors.
```
(() => {
  const themes = [
    'theme--backdrop-blue-circles',
    'theme--backdrop-blue-green-wave',
    'theme--backdrop-blue-purple-fade',
    'theme--backdrop-green',
    'theme--backdrop-indigo',
    'theme--backdrop-seafoam',
    'theme--blue',
    'theme--cinnamon',
    'theme--cyan',
    'theme--fuchsia',
    'theme--indigo',
    'theme--no-color',
    'theme--orange',
    'theme--red',
    'theme--seafoam',
  ];
  let i = 0;
  document.addEventListener('click', () => {
    document.body.classList.remove(...themes);
    document.body.classList.add(themes[i % themes.length]);
    console.log(themes[i % themes.length]);
    i++;
  });
})();

```
4. Confirm responsiveness of quote changes.

Example articles:
- This one has subtitle text on a quote `/ideas/behind-the-design-adobe-express-ai-assistant`
- This one has an unconventional use of quote for formatting purpose on a non-quote and would need to be modified (to discuss): `/ideas/the-creative-cloud-features-adobe-s-designers-can-t-live-without1`

---

## Browser Testing
We should aim to support the latest version of the listed browsers. For older versions or other browsers not on the list, content should be accessible, even if it doesn't completely match the designs.

Developers should test as they work in the browsers available on their machines. If they have access to other devices to test other browser/OS combinations, they should do that when possible.

**Windows**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**MacOS**
* [ ] Firefox
* [ ] Chrome
* [ ] Safari
* [ ] Edge

**Android**
* [ ] Firefox
* [ ] Chrome
* [ ] Edge

**iOS**
* [ ] Safari

---
